### PR TITLE
feat: frontend polish — PWA, skeletons, a11y, lazy images

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,11 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1a1714" />
+    <meta name="description" content="AI-powered wardrobe management, outfit recommendations, and virtual try-on." />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
     <title>OutfitAI — Smart Wardrobe</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -16,5 +21,12 @@
     </script>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function() {
+          navigator.serviceWorker.register('/sw.js')
+        })
+      }
+    </script>
   </body>
 </html>

--- a/frontend/public/icons/icon-192.svg
+++ b/frontend/public/icons/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="40" fill="#1a1714"/>
+  <path d="M96 40L40 68l56 28 56-28-56-28zM40 124l56 28 56-28M40 96l56 28 56-28" stroke="#e5a040" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "OutfitAI — Smart Wardrobe Recommender",
+  "short_name": "OutfitAI",
+  "description": "AI-powered wardrobe management, outfit recommendations, and virtual try-on.",
+  "start_url": "/dashboard",
+  "display": "standalone",
+  "background_color": "#faf9f7",
+  "theme_color": "#1a1714",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["lifestyle", "fashion"],
+  "lang": "en"
+}

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Offline — OutfitAI</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'DM Sans', system-ui, sans-serif;
+      background: #faf9f7;
+      color: #1a1714;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .container {
+      text-align: center;
+      max-width: 400px;
+    }
+    .icon {
+      width: 80px;
+      height: 80px;
+      border-radius: 20px;
+      background: #f5f3ef;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2rem;
+      margin: 0 auto 1.5rem;
+    }
+    h1 {
+      font-family: 'Playfair Display', Georgia, serif;
+      font-size: 1.75rem;
+      margin-bottom: 0.75rem;
+    }
+    p {
+      color: #78716c;
+      font-size: 0.9rem;
+      line-height: 1.6;
+      margin-bottom: 1.5rem;
+    }
+    button {
+      background: #1a1714;
+      color: white;
+      border: none;
+      padding: 0.75rem 2rem;
+      border-radius: 10px;
+      font-size: 0.9rem;
+      font-weight: 500;
+      cursor: pointer;
+    }
+    button:hover { background: #2c2822; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">&#128246;</div>
+    <h1>You're Offline</h1>
+    <p>OutfitAI needs an internet connection to load your wardrobe and generate recommendations. Please check your connection and try again.</p>
+    <button onclick="window.location.reload()">Retry</button>
+  </div>
+</body>
+</html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,28 @@
+const CACHE_NAME = 'outfitai-v1'
+const OFFLINE_URL = '/offline.html'
+
+const PRECACHE_URLS = [OFFLINE_URL]
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  )
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  )
+  self.clients.claim()
+})
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+    )
+  }
+})

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { useAuth } from './context/AuthContext.jsx'
 import AuthGuard from './guards/AuthGuard.jsx'
+import ErrorBoundary from './components/ui/ErrorBoundary.jsx'
 import Navbar from './components/layout/Navbar.jsx'
 
 import LoginPage from './pages/LoginPage.jsx'
@@ -20,8 +21,15 @@ import OnboardingFlow from './components/onboarding/OnboardingFlow.jsx'
 function Layout({ children }) {
   return (
     <div className="min-h-screen bg-brand-50 dark:bg-brand-950">
+      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-brand-900 focus:text-white focus:rounded-lg focus:text-sm focus:font-medium">
+        Skip to content
+      </a>
       <Navbar />
-      {children}
+      <main id="main-content">
+        <ErrorBoundary>
+          {children}
+        </ErrorBoundary>
+      </main>
     </div>
   )
 }

--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -137,7 +137,7 @@ export default function OOTDWidget() {
             >
               <div className="w-20 h-20 rounded-xl overflow-hidden bg-brand-100/60 dark:bg-brand-800/40 border border-brand-100/60 dark:border-brand-700/40 shadow-sm">
                 {item.image_url && (
-                  <img src={`${API_URL}${item.image_url}`} alt={item.category} className="w-full h-full object-cover" />
+                  <img src={`${API_URL}${item.image_url}`} alt={item.category} loading="lazy" decoding="async" className="w-full h-full object-cover" />
                 )}
               </div>
               <p className="text-[11px] text-brand-500 dark:text-brand-400 text-center mt-1.5 capitalize">{item.category}</p>

--- a/frontend/src/components/layout/Navbar.jsx
+++ b/frontend/src/components/layout/Navbar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { NavLink, useNavigate } from 'react-router-dom'
+import { NavLink, useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../../context/AuthContext.jsx'
 import { motion, AnimatePresence } from 'framer-motion'
 import { FiHome, FiGrid, FiStar, FiCalendar, FiBookmark, FiClock, FiLogOut, FiEdit3, FiMenu, FiX, FiUsers, FiSettings } from 'react-icons/fi'
@@ -24,6 +24,11 @@ export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false)
   const [avatarError, setAvatarError] = useState(false)
 
+  const location = useLocation()
+
+  // Close mobile menu on route change
+  useEffect(() => { setMobileOpen(false) }, [location.pathname])
+
   // Reset error state whenever the avatar URL changes (new upload)
   useEffect(() => { setAvatarError(false) }, [user?.avatar_url])
 
@@ -34,7 +39,7 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="sticky top-0 z-40 bg-white/70 dark:bg-brand-900/70 backdrop-blur-xl border-b border-brand-100/60 dark:border-brand-800/40">
+      <nav className="sticky top-0 z-40 bg-white/70 dark:bg-brand-900/70 backdrop-blur-xl border-b border-brand-100/60 dark:border-brand-800/40" aria-label="Main navigation">
         <div className="max-w-6xl mx-auto px-4 sm:px-6">
           <div className="h-16 flex items-center justify-between">
             {/* Logo */}
@@ -115,6 +120,8 @@ export default function Navbar() {
               <button
                 onClick={() => setMobileOpen(o => !o)}
                 className="md:hidden p-2 rounded-lg text-brand-500 hover:bg-brand-100 dark:hover:bg-brand-800 transition-colors"
+                aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+                aria-expanded={mobileOpen}
               >
                 {mobileOpen ? <FiX size={20} /> : <FiMenu size={20} />}
               </button>
@@ -126,6 +133,16 @@ export default function Navbar() {
       {/* Mobile slide-down menu */}
       <AnimatePresence>
         {mobileOpen && (
+          <>
+          {/* Backdrop to dismiss on tap */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="md:hidden fixed inset-0 top-16 z-20 bg-black/20"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden="true"
+          />
           <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
@@ -180,6 +197,7 @@ export default function Navbar() {
               </div>
             </div>
           </motion.div>
+          </>
         )}
       </AnimatePresence>
     </>

--- a/frontend/src/components/social/FeedCard.jsx
+++ b/frontend/src/components/social/FeedCard.jsx
@@ -81,6 +81,8 @@ export default function FeedCard({ post, onRemixClick, onVibeClick, onPostClick 
             <img
               src={previewUrl}
               alt="Outfit preview"
+              loading="lazy"
+              decoding="async"
               className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
               onError={() => setImageError(true)}
             />
@@ -250,6 +252,8 @@ function ItemMosaic({ images, occasion, score }) {
             <img
               src={`${BASE}${url}`}
               alt=""
+              loading="lazy"
+              decoding="async"
               className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
               onError={e => {
                 e.currentTarget.style.display = 'none'

--- a/frontend/src/components/ui/ErrorBoundary.jsx
+++ b/frontend/src/components/ui/ErrorBoundary.jsx
@@ -1,0 +1,40 @@
+import { Component } from 'react'
+import { FiAlertTriangle, FiRefreshCw } from 'react-icons/fi'
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error }
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children
+
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center px-4">
+        <div className="text-center max-w-md">
+          <div className="w-16 h-16 rounded-2xl bg-red-50 dark:bg-red-900/20 flex items-center justify-center mx-auto mb-5">
+            <FiAlertTriangle size={28} className="text-red-500" />
+          </div>
+          <h2 className="font-display text-2xl font-bold text-brand-900 dark:text-brand-100 mb-2">
+            Something went wrong
+          </h2>
+          <p className="text-sm text-brand-500 dark:text-brand-400 mb-6">
+            An unexpected error occurred. Please refresh the page to try again.
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            className="btn-primary inline-flex items-center gap-2"
+          >
+            <FiRefreshCw size={14} />
+            Refresh Page
+          </button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/frontend/src/components/ui/LazyImage.jsx
+++ b/frontend/src/components/ui/LazyImage.jsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+
+export default function LazyImage({ src, alt, className = '', fallback, ...props }) {
+  const [loaded, setLoaded] = useState(false)
+  const [error, setError] = useState(false)
+
+  if (error && fallback) return fallback
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      decoding="async"
+      onLoad={() => setLoaded(true)}
+      onError={() => setError(true)}
+      className={`transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'} ${className}`}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/components/wardrobe/WardrobeCard.jsx
+++ b/frontend/src/components/wardrobe/WardrobeCard.jsx
@@ -55,6 +55,8 @@ export default function WardrobeCard({ item, onDelete }) {
             <img
               src={imageUrl}
               alt={`${item.category} item`}
+              loading="lazy"
+              decoding="async"
               className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
               onError={e => { e.target.style.display = 'none' }}
             />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -185,3 +185,31 @@ input[type="range"]::-webkit-slider-thumb {
   @apply focus:outline-none focus:ring-2 focus:ring-accent-400/40 focus:ring-offset-2
          focus:ring-offset-brand-50 dark:focus:ring-offset-brand-950;
 }
+
+/* ─── Keyboard-only focus (visible only on Tab, not click) ─── */
+*:focus-visible {
+  @apply outline-2 outline-offset-2 outline-accent-500;
+}
+
+/* ─── Screen reader only (used for skip links) ─── */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ─── Reduced motion preference ─── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/frontend/src/pages/HistoryPage.jsx
+++ b/frontend/src/pages/HistoryPage.jsx
@@ -7,7 +7,6 @@ import { getHistory } from '../api/outfits.js'
 import { saveOutfit } from '../api/outfits.js'
 import PageWrapper from '../components/layout/PageWrapper.jsx'
 import OutfitItems from '../components/recommendations/OutfitItems.jsx'
-import LoadingSpinner from '../components/ui/LoadingSpinner.jsx'
 import ErrorMessage from '../components/ui/ErrorMessage.jsx'
 import EmptyState from '../components/ui/EmptyState.jsx'
 import ShareButton from '../components/ui/ShareButton.jsx'
@@ -56,7 +55,22 @@ export default function HistoryPage() {
           <p className="text-brand-500 dark:text-brand-400 mt-1">Your past outfit recommendations</p>
         </div>
 
-        {isLoading && <LoadingSpinner className="py-16" size="lg" />}
+        {isLoading && (
+          <div className="space-y-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="card p-5">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="skeleton h-5 w-16 rounded-full" />
+                  <div className="skeleton h-4 w-12 rounded" />
+                  <div className="skeleton h-4 w-20 rounded ml-auto" />
+                </div>
+                <div className="flex gap-2">
+                  {[1,2,3].map(j => <div key={j} className="skeleton w-16 h-16 rounded-xl" />)}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
         {error && <ErrorMessage message="Could not load history." onRetry={refetch} />}
 
         {!isLoading && !error && history.length === 0 && (

--- a/frontend/src/pages/SavedOutfitsPage.jsx
+++ b/frontend/src/pages/SavedOutfitsPage.jsx
@@ -5,7 +5,6 @@ import { FiTrash2, FiStar, FiChevronRight, FiGrid, FiList, FiShare2, FiUser } fr
 import { getSaved, deleteSaved } from '../api/outfits.js'
 import PageWrapper from '../components/layout/PageWrapper.jsx'
 import OutfitItems from '../components/recommendations/OutfitItems.jsx'
-import LoadingSpinner from '../components/ui/LoadingSpinner.jsx'
 import ErrorMessage from '../components/ui/ErrorMessage.jsx'
 import EmptyState from '../components/ui/EmptyState.jsx'
 import ConfirmDialog from '../components/ui/ConfirmDialog.jsx'
@@ -71,7 +70,21 @@ export default function SavedOutfitsPage() {
           </div>
         </motion.div>
 
-        {isLoading && <LoadingSpinner className="py-32" size="lg" />}
+        {isLoading && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="card-glass p-6">
+                <div className="skeleton h-3 w-20 rounded mb-2" />
+                <div className="skeleton h-6 w-36 rounded mb-6" />
+                <div className="skeleton h-32 w-full rounded-2xl mb-8" />
+                <div className="flex justify-between">
+                  <div className="skeleton h-5 w-16 rounded-full" />
+                  <div className="skeleton h-5 w-20 rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
         {error && <ErrorMessage message="The gallery could not be synchronized." onRetry={refetch} />}
 
         {!isLoading && !error && outfits.length === 0 && (

--- a/frontend/src/pages/SocialFeedPage.jsx
+++ b/frontend/src/pages/SocialFeedPage.jsx
@@ -9,7 +9,6 @@ import FeedCard from '../components/social/FeedCard.jsx'
 import RemixResultModal from '../components/social/RemixResultModal.jsx'
 import PostDetailModal from '../components/social/PostDetailModal.jsx'
 import VibeTagPill from '../components/social/VibeTagPill.jsx'
-import LoadingSpinner from '../components/ui/LoadingSpinner.jsx'
 import EmptyState from '../components/ui/EmptyState.jsx'
 
 const TABS = [
@@ -136,7 +135,26 @@ export default function SocialFeedPage() {
         </div>
 
         {/* Feed grid */}
-        {isLoading && <LoadingSpinner className="py-24" size="lg" />}
+        {isLoading && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="card overflow-hidden">
+                <div className="skeleton aspect-square" />
+                <div className="p-3 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <div className="skeleton w-6 h-6 rounded-full" />
+                    <div className="skeleton h-3 w-20 rounded" />
+                  </div>
+                  <div className="skeleton h-3 w-full rounded" />
+                  <div className="flex gap-1">
+                    <div className="skeleton h-5 w-12 rounded-full" />
+                    <div className="skeleton h-5 w-14 rounded-full" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
 
         {isError && (
           <EmptyState

--- a/frontend/src/pages/WardrobePage.jsx
+++ b/frontend/src/pages/WardrobePage.jsx
@@ -1,12 +1,11 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
-import { FiCamera, FiPlus } from 'react-icons/fi'
+import { FiPlus } from 'react-icons/fi'
 import { getItems, deleteItem } from '../api/wardrobe.js'
 import PageWrapper from '../components/layout/PageWrapper.jsx'
 import WardrobeGrid from '../components/wardrobe/WardrobeGrid.jsx'
 import UploadModal from '../components/wardrobe/UploadModal.jsx'
-import LoadingSpinner from '../components/ui/LoadingSpinner.jsx'
 import ErrorMessage from '../components/ui/ErrorMessage.jsx'
 
 const CATEGORIES = ['all', 'top', 'bottom', 'outwear', 'shoes', 'dress', 'jumpsuit']
@@ -81,7 +80,19 @@ export default function WardrobePage() {
         </div>
 
         {/* Content */}
-        {isLoading && <LoadingSpinner className="py-16" size="lg" />}
+        {isLoading && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+            {Array.from({ length: 10 }).map((_, i) => (
+              <div key={i} className="card overflow-hidden">
+                <div className="skeleton aspect-square" />
+                <div className="p-3 space-y-2">
+                  <div className="skeleton h-4 w-16 rounded" />
+                  <div className="skeleton h-3 w-24 rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
         {error && <ErrorMessage message="Could not load wardrobe." onRetry={refetch} />}
         {!isLoading && !error && (
           <WardrobeGrid


### PR DESCRIPTION
## Summary
- **PWA setup**: manifest.json, service worker with offline fallback, iOS meta tags
- **Loading skeletons**: Replace spinners with content-shaped skeleton loaders on Wardrobe, Saved Outfits, History, and Social Feed pages
- **Error boundary**: Global ErrorBoundary component wrapping all page content
- **Accessibility**: Skip-to-content link, ARIA labels on nav/menu, focus-visible outlines, prefers-reduced-motion support
- **Image lazy loading**: Native `loading="lazy"` + `decoding="async"` on all wardrobe/feed/OOTD images
- **Mobile UX**: Backdrop overlay to dismiss nav menu, auto-close on route change

## Phase 3 task coverage
- [x] 3.2 Fix mobile issues (nav dismiss, route-aware menu)
- [x] 3.3 Add loading skeletons (4 pages)
- [x] 3.4 Improve error states (ErrorBoundary)
- [x] 3.5 Empty states (already present on all pages)
- [x] 3.6 VTO UX (done in prior session)
- [x] 3.7 PWA setup (manifest, SW, offline page)
- [x] 3.8 Image optimization (lazy loading)
- [x] 3.9 Accessibility (skip link, ARIA, focus, reduced motion)
- [ ] 3.1 Responsive audit (requires browser testing)

## Test plan
- [x] `npm run build` — passes
- [x] ESLint — 0 errors, 17 warnings (within threshold)
- [ ] Manual: test PWA install prompt on mobile
- [ ] Manual: verify offline page shows when disconnected
- [ ] Manual: verify skeletons appear during loading
- [ ] Manual: test skip-to-content with Tab key