### PR TITLE
feat: Phase 6 — Security hardening & user data consent

### DIFF
--- a/app/audit.py
+++ b/app/audit.py
@@ -1,0 +1,63 @@
+"""
+app/audit.py
+Audit logging helper — records security-relevant actions.
+
+Usage:
+    from app.audit import log_action
+    log_action("login", user_id=1, detail="email login")
+    log_action("login_failed", detail="bad password for test@example.com")
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import request
+
+from app.extensions import db
+from app.models_db import AuditLog
+
+logger = logging.getLogger(__name__)
+
+# Actions that are recorded
+ACTIONS = {
+    "login",
+    "login_failed",
+    "register",
+    "upload_item",
+    "delete_item",
+    "delete_account",
+    "consent_granted",
+    "consent_revoked",
+    "data_export",
+    "vto_job_submitted",
+    "password_changed",
+}
+
+
+def log_action(action: str, user_id: int | None = None, detail: str | None = None) -> None:
+    """
+    Write an audit log entry. Fire-and-forget — never raises.
+
+    Args:
+        action: one of the ACTIONS constants (e.g. "login", "upload_item")
+        user_id: authenticated user ID, or None for anonymous actions
+        detail: optional human-readable context (truncated to 500 chars)
+    """
+    try:
+        ip = request.remote_addr if request else None
+    except RuntimeError:
+        ip = None
+
+    try:
+        entry = AuditLog(
+            user_id=user_id,
+            action=action,
+            detail=(detail or "")[:500] or None,
+            ip_address=ip,
+        )
+        db.session.add(entry)
+        db.session.commit()
+    except Exception as exc:
+        logger.warning("Audit log write failed: %s", exc)
+        db.session.rollback()

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -17,7 +17,7 @@ from flask_jwt_extended import (
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.extensions import db, bcrypt
+from app.extensions import db, bcrypt, limiter
 from app.models_db import User, UserConsent, WardrobeItemDB, OutfitHistory, SavedOutfit, OutfitFeedback
 from app.audit import log_action
 
@@ -27,6 +27,7 @@ VALID_GENDERS = {"men", "women", "unisex"}
 
 
 @auth_bp.route("/register", methods=["POST"])
+@limiter.limit("3/minute")
 def register():
     """
     POST /auth/register
@@ -67,6 +68,7 @@ def register():
 
 
 @auth_bp.route("/login", methods=["POST"])
+@limiter.limit("5/minute")
 def login():
     """
     POST /auth/login
@@ -387,6 +389,8 @@ def change_password():
         return jsonify({"error": "New password must be at least 8 characters."}), 422
 
     user = db.session.get(User, user_id)
+    if not user:
+        return jsonify({"error": "User not found."}), 404
     if not bcrypt.check_password_hash(user.password_hash, current_pw):
         return jsonify({"error": "Current password is incorrect."}), 401
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,9 +1,12 @@
 """
 app/auth/routes.py
-Authentication endpoints: register, login, refresh.
+Authentication endpoints: register, login, refresh, consent, privacy.
 """
 
 from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
 
 from flask import Blueprint, request, jsonify, current_app
 from flask_jwt_extended import (
@@ -15,7 +18,8 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.extensions import db, bcrypt
-from app.models_db import User
+from app.models_db import User, UserConsent, WardrobeItemDB, OutfitHistory, SavedOutfit, OutfitFeedback
+from app.audit import log_action
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -58,6 +62,7 @@ def register():
     db.session.add(user)
     db.session.commit()
 
+    log_action("register", user_id=user.id, detail=f"email={email}")
     return jsonify({"message": "Account created.", "user_id": user.id}), 201
 
 
@@ -95,6 +100,7 @@ def login():
 
     password_hash = user.password_hash if user is not None else (fallback_row["password_hash"] if fallback_row else None)
     if not password_hash or not bcrypt.check_password_hash(password_hash, password):
+        log_action("login_failed", detail=f"email={email}")
         return jsonify({"error": "Invalid email or password."}), 401
 
     user_id = user.id if user is not None else int(fallback_row["id"])
@@ -102,6 +108,7 @@ def login():
     gender = user.gender if user is not None else str(fallback_row["gender"])
 
     access_token = create_access_token(identity=str(user_id))
+    log_action("login", user_id=user_id, detail=f"email={email}")
     return jsonify({
         "access_token": access_token,
         "user_id":      user_id,
@@ -125,3 +132,266 @@ def refresh():
     user_id = get_jwt_identity()  # str
     new_token = create_access_token(identity=user_id)
     return jsonify({"access_token": new_token}), 200
+
+
+# ── Consent types ──────────────────────────────────────────────────────────────
+
+CONSENT_TYPES = {
+    "data_training": "Allow your wardrobe data and outfit preferences to be used for model improvement.",
+    "analytics":     "Allow anonymous usage analytics to help us improve the app experience.",
+}
+
+CURRENT_POLICY_VERSION = "1.0"
+
+
+@auth_bp.route("/consent", methods=["GET"])
+@jwt_required()
+def get_consent():
+    """
+    GET /auth/consent
+    Returns the user's current consent status for all consent types.
+    """
+    user_id = int(get_jwt_identity())
+
+    result = {}
+    for ctype, description in CONSENT_TYPES.items():
+        consent = (
+            UserConsent.query
+            .filter_by(user_id=user_id, consent_type=ctype)
+            .order_by(UserConsent.id.desc())
+            .first()
+        )
+        result[ctype] = {
+            "granted":     consent.granted if consent else False,
+            "version":     consent.version if consent else CURRENT_POLICY_VERSION,
+            "granted_at":  consent.granted_at.isoformat() if consent and consent.granted else None,
+            "revoked_at":  consent.revoked_at.isoformat() if consent and consent.revoked_at else None,
+            "description": description,
+        }
+
+    return jsonify({"consents": result}), 200
+
+
+@auth_bp.route("/consent", methods=["PATCH"])
+@jwt_required()
+def update_consent():
+    """
+    PATCH /auth/consent
+    Body: { "data_training": true, "analytics": false }
+    Updates consent for the specified types. Creates audit trail entries.
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+
+    if not data:
+        return jsonify({"error": "Request body must contain consent type(s)."}), 422
+
+    ip = request.remote_addr
+    updated = []
+
+    for ctype, granted in data.items():
+        if ctype not in CONSENT_TYPES:
+            return jsonify({"error": f"Unknown consent type: '{ctype}'."}), 422
+        if not isinstance(granted, bool):
+            return jsonify({"error": f"Value for '{ctype}' must be true or false."}), 422
+
+        # Get the latest consent record for this type
+        existing = (
+            UserConsent.query
+            .filter_by(user_id=user_id, consent_type=ctype)
+            .order_by(UserConsent.id.desc())
+            .first()
+        )
+
+        if existing and existing.granted == granted:
+            # No change needed
+            updated.append(ctype)
+            continue
+
+        if existing and existing.granted and not granted:
+            # Revoking: update the existing record
+            existing.granted = False
+            existing.revoked_at = datetime.now(timezone.utc)
+            log_action("consent_revoked", user_id=user_id, detail=f"type={ctype} version={existing.version}")
+        else:
+            # Granting (new or re-grant after revoke): create a new record
+            consent = UserConsent(
+                user_id=user_id,
+                consent_type=ctype,
+                granted=True,
+                version=CURRENT_POLICY_VERSION,
+                ip_address=ip,
+            )
+            db.session.add(consent)
+            log_action("consent_granted", user_id=user_id, detail=f"type={ctype} version={CURRENT_POLICY_VERSION}")
+
+        updated.append(ctype)
+
+    db.session.commit()
+    return jsonify({"message": "Consent updated.", "updated": updated}), 200
+
+
+@auth_bp.route("/privacy-summary", methods=["GET"])
+@jwt_required()
+def privacy_summary():
+    """
+    GET /auth/privacy-summary
+    Returns a summary of the user's data footprint for the privacy dashboard.
+    """
+    user_id = int(get_jwt_identity())
+
+    item_count = WardrobeItemDB.query.filter_by(user_id=user_id).count()
+    outfit_count = OutfitHistory.query.filter_by(user_id=user_id).count()
+    saved_count = SavedOutfit.query.filter_by(user_id=user_id).count()
+    feedback_count = OutfitFeedback.query.filter_by(user_id=user_id).count()
+
+    user = db.session.get(User, user_id)
+
+    return jsonify({
+        "user_id": user_id,
+        "email": user.email,
+        "account_created": user.created_at.isoformat() if user.created_at else None,
+        "data_summary": {
+            "wardrobe_items": item_count,
+            "outfit_history": outfit_count,
+            "saved_outfits": saved_count,
+            "feedback_given": feedback_count,
+            "has_person_photo": bool(user.profile_photo_filename),
+        },
+    }), 200
+
+
+@auth_bp.route("/data-export", methods=["GET"])
+@jwt_required()
+def data_export():
+    """
+    GET /auth/data-export
+    Returns all user data as a JSON download (GDPR-style data portability).
+    """
+    user_id = int(get_jwt_identity())
+    user = db.session.get(User, user_id)
+
+    items = WardrobeItemDB.query.filter_by(user_id=user_id).all()
+    history = OutfitHistory.query.filter_by(user_id=user_id).all()
+    saved = SavedOutfit.query.filter_by(user_id=user_id).all()
+    feedback = OutfitFeedback.query.filter_by(user_id=user_id).all()
+    consents = UserConsent.query.filter_by(user_id=user_id).all()
+
+    export = {
+        "user": {
+            "id": user.id,
+            "name": user.name,
+            "email": user.email,
+            "gender": user.gender,
+            "created_at": user.created_at.isoformat() if user.created_at else None,
+        },
+        "wardrobe_items": [
+            {
+                "id": i.id,
+                "category": i.category,
+                "sub_category": i.sub_category,
+                "formality": i.formality,
+                "gender": i.gender,
+                "created_at": i.created_at.isoformat() if i.created_at else None,
+            }
+            for i in items
+        ],
+        "outfit_history": [
+            {
+                "id": h.id,
+                "occasion": h.occasion,
+                "temperature": h.temperature_used,
+                "item_ids": json.loads(h.item_ids) if h.item_ids else [],
+                "score": h.final_score,
+                "logged_at": h.logged_at.isoformat() if h.logged_at else None,
+            }
+            for h in history
+        ],
+        "saved_outfits": [
+            {
+                "id": s.id,
+                "name": s.name,
+                "occasion": s.occasion,
+                "item_ids": json.loads(s.item_ids) if s.item_ids else [],
+                "score": s.final_score,
+                "saved_at": s.saved_at.isoformat() if s.saved_at else None,
+            }
+            for s in saved
+        ],
+        "feedback": [
+            {
+                "id": f.id,
+                "history_id": f.history_id,
+                "rating": f.rating,
+                "created_at": f.created_at.isoformat() if f.created_at else None,
+            }
+            for f in feedback
+        ],
+        "consents": [c.to_dict() for c in consents],
+    }
+
+    log_action("data_export", user_id=user_id)
+
+    response = jsonify(export)
+    response.headers["Content-Disposition"] = f"attachment; filename=outfitai_data_{user_id}.json"
+    return response, 200
+
+
+@auth_bp.route("/account", methods=["DELETE"])
+@jwt_required()
+def delete_account():
+    """
+    DELETE /auth/account
+    Permanently deletes the user account and all associated data.
+    Requires password confirmation in the request body.
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+
+    password = str(data.get("password", ""))
+    if not password:
+        return jsonify({"error": "Password confirmation is required."}), 422
+
+    user = db.session.get(User, user_id)
+    if not user:
+        return jsonify({"error": "User not found."}), 404
+
+    if not bcrypt.check_password_hash(user.password_hash, password):
+        return jsonify({"error": "Incorrect password."}), 401
+
+    log_action("delete_account", user_id=user_id, detail=f"email={user.email}")
+
+    # Cascade delete handles wardrobe_items, outfit_history, saved_outfits, etc.
+    db.session.delete(user)
+    db.session.commit()
+
+    return jsonify({"message": "Account permanently deleted."}), 200
+
+
+@auth_bp.route("/change-password", methods=["POST"])
+@jwt_required()
+def change_password():
+    """
+    POST /auth/change-password
+    Body: { "current_password": "...", "new_password": "..." }
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+
+    current_pw = str(data.get("current_password", ""))
+    new_pw = str(data.get("new_password", ""))
+
+    if not current_pw or not new_pw:
+        return jsonify({"error": "current_password and new_password are required."}), 422
+    if len(new_pw) < 8:
+        return jsonify({"error": "New password must be at least 8 characters."}), 422
+
+    user = db.session.get(User, user_id)
+    if not bcrypt.check_password_hash(user.password_hash, current_pw):
+        return jsonify({"error": "Current password is incorrect."}), 401
+
+    user.password_hash = bcrypt.generate_password_hash(new_pw).decode("utf-8")
+    db.session.commit()
+
+    log_action("password_changed", user_id=user_id)
+    return jsonify({"message": "Password changed successfully."}), 200

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -13,10 +13,27 @@ from flask_compress import Compress
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
+
+def _rate_limit_key():
+    """
+    Per-user rate limiting: use JWT user ID for authenticated requests,
+    fall back to IP address for unauthenticated (login, register, public).
+    """
+    try:
+        from flask_jwt_extended import get_jwt_identity, verify_jwt_in_request
+        verify_jwt_in_request(optional=True)
+        uid = get_jwt_identity()
+        if uid:
+            return f"user:{uid}"
+    except Exception:
+        pass
+    return get_remote_address()
+
+
 db       = SQLAlchemy()
 migrate  = Migrate()
 jwt      = JWTManager()
 bcrypt   = Bcrypt()
 cors     = CORS()
 compress = Compress()
-limiter  = Limiter(key_func=get_remote_address, default_limits=[])
+limiter  = Limiter(key_func=_rate_limit_key, default_limits=[])

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,9 +1,10 @@
 """
 app/middleware.py
-Request-level middleware for observability.
+Request-level middleware for observability and security.
 
 - Request ID: UUID attached to every request, propagated through logs and
   returned in the X-Request-ID response header.
+- Security headers: CSP, X-Content-Type-Options, X-Frame-Options, etc.
 - Structured JSON logging: replaces default text logs with machine-readable
   JSON lines (timestamp, level, request_id, user_id, message).
 """
@@ -28,9 +29,26 @@ def _before_request():
 
 
 def _after_request(response):
-    """Inject request ID into response headers and log the request."""
+    """Inject request ID, security headers, and log the request."""
     req_id = getattr(g, "request_id", "-")
     response.headers["X-Request-ID"] = req_id
+
+    # ── Security headers ──────────────────────────────────────────────────
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(self)"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com; "
+        "img-src 'self' data: blob: https:; "
+        "connect-src 'self' https://*.hf.space https://nominatim.openstreetmap.org https://api.open-meteo.com; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self'; "
+        "form-action 'self'"
+    )
 
     # Log completed request
     duration_ms = 0.0

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -396,3 +396,66 @@ class TryOnJob(db.Model):
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
         }
+
+
+# ── Audit Log ────────────────────────────────────────────────────────────────
+
+class AuditLog(db.Model):
+    """
+    Immutable audit trail for security-relevant actions.
+
+    Every row records WHO did WHAT and WHEN. Rows are never updated or deleted.
+    """
+    __tablename__ = "audit_log"
+
+    id         = db.Column(db.Integer, primary_key=True)
+    user_id    = db.Column(db.Integer, nullable=True, index=True)   # null for failed logins
+    action     = db.Column(db.String(50), nullable=False, index=True)
+    detail     = db.Column(db.String(500), nullable=True)
+    ip_address = db.Column(db.String(45), nullable=True)            # IPv4 or IPv6
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "action": self.action,
+            "detail": self.detail,
+            "ip_address": self.ip_address,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+
+
+# ── User Consent ─────────────────────────────────────────────────────────────
+
+class UserConsent(db.Model):
+    """
+    Tracks explicit user consent for data usage.
+
+    Each row is one consent type for one user. When consent is revoked,
+    `granted` is set to False and `revoked_at` is timestamped.
+    A new row is created if consent is re-granted after revocation (audit trail).
+    """
+    __tablename__ = "user_consents"
+
+    id           = db.Column(db.Integer, primary_key=True)
+    user_id      = db.Column(db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    consent_type = db.Column(db.String(30), nullable=False)   # "data_training", "analytics"
+    granted      = db.Column(db.Boolean, nullable=False, default=False)
+    version      = db.Column(db.String(10), nullable=False, default="1.0")  # policy version
+    ip_address   = db.Column(db.String(45), nullable=True)
+    granted_at   = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    revoked_at   = db.Column(db.DateTime, nullable=True)
+
+    __table_args__ = (
+        db.Index("ix_consent_lookup", "user_id", "consent_type"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "consent_type": self.consent_type,
+            "granted": self.granted,
+            "version": self.version,
+            "granted_at": self.granted_at.isoformat() if self.granted_at else None,
+            "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
+        }

--- a/app/utils.py
+++ b/app/utils.py
@@ -26,16 +26,27 @@ def allowed_file(filename: str, allowed_extensions: set[str]) -> bool:
     )
 
 
+_MAGIC_BYTES = {
+    b"\x89PNG\r\n\x1a\n": "image/png",
+    b"\xff\xd8\xff": "image/jpeg",
+}
+
+
 def validate_image_content(content: bytes) -> bool:
     """
     Return True if the bytes represent a valid image.
 
-    Uses Pillow's Image.verify() which actually parses the file format —
-    a malicious file that fakes a .jpg extension cannot pass this check.
-
-    Note: verify() "consumes" the image object; the raw bytes in `content`
-    remain safe to write to disk afterwards.
+    Two-layer validation:
+      1. Magic byte check — reject files that don't start with PNG/JPEG signatures.
+      2. Pillow verify() — actually parses the file format; catches truncated or
+         malicious files that fake an extension.
     """
+    # Layer 1: magic bytes
+    if not any(content.startswith(sig) for sig in _MAGIC_BYTES):
+        logger.debug("Image validation failed: unrecognised magic bytes")
+        return False
+
+    # Layer 2: Pillow structural check
     try:
         from PIL import Image
         img = Image.open(io.BytesIO(content))

--- a/app/vto/routes.py
+++ b/app/vto/routes.py
@@ -36,6 +36,7 @@ from flask_jwt_extended import get_jwt_identity, jwt_required
 from app.extensions import db
 from app.models_db import TryOnJob, User, WardrobeItemDB
 from app.utils import allowed_file, validate_image_content
+from app.audit import log_action
 
 logger = logging.getLogger(__name__)
 
@@ -323,6 +324,7 @@ def submit_tryon():
     t.start()
 
     logger.info("VTO job %d submitted (user=%d, item=%d)", job.id, user_id, item_id)
+    log_action("vto_job_submitted", user_id=user_id, detail=f"job_id={job.id} item_id={item_id}")
 
     return jsonify({**job.to_dict(), "cached": False}), 202
 

--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -31,6 +31,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from sqlalchemy import func
 
+from app.audit import log_action
 from app.cache import recommendation_cache
 from app.extensions import db
 from app.models_db import WardrobeItemDB, OutfitHistory, OutfitFeedback, SavedOutfit, User
@@ -212,6 +213,7 @@ def upload_item():
     db.session.add(item)
     db.session.commit()
     recommendation_cache.invalidate_user(user_id)
+    log_action("upload_item", user_id=user_id, detail=f"item_id={item.id} category={category}")
 
     # ── 9. Return with upload guidance ────────────────────────────────────────
     return jsonify({**item.to_dict(), "tips": UPLOAD_TIPS, "bg_removed": bg_removed}), 201
@@ -259,6 +261,7 @@ def delete_item(item_id: int):
     db.session.delete(item)
     db.session.commit()
     recommendation_cache.invalidate_user(user_id)
+    log_action("delete_item", user_id=user_id, detail=f"item_id={item_id}")
     return jsonify({"message": "Item deleted."}), 200
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom'
 import { useAuth } from './context/AuthContext.jsx'
 import AuthGuard from './guards/AuthGuard.jsx'
 import ErrorBoundary from './components/ui/ErrorBoundary.jsx'
+import ConsentBanner from './components/ui/ConsentBanner.jsx'
 import Navbar from './components/layout/Navbar.jsx'
 
 import LoginPage from './pages/LoginPage.jsx'
@@ -30,6 +31,7 @@ function Layout({ children }) {
           {children}
         </ErrorBoundary>
       </main>
+      <ConsentBanner />
     </div>
   )
 }

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -8,3 +8,21 @@ export const login = (data) =>
 
 export const refreshToken = () =>
   api.post('/auth/refresh').then(r => r.data)
+
+export const getConsent = () =>
+  api.get('/auth/consent').then(r => r.data)
+
+export const updateConsent = (data) =>
+  api.patch('/auth/consent', data).then(r => r.data)
+
+export const getPrivacySummary = () =>
+  api.get('/auth/privacy-summary').then(r => r.data)
+
+export const exportData = () =>
+  api.get('/auth/data-export').then(r => r.data)
+
+export const deleteAccount = (data) =>
+  api.delete('/auth/account', { data }).then(r => r.data)
+
+export const changePassword = (data) =>
+  api.post('/auth/change-password', data).then(r => r.data)

--- a/frontend/src/components/ui/ConsentBanner.jsx
+++ b/frontend/src/components/ui/ConsentBanner.jsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { motion, AnimatePresence } from 'framer-motion'
+import { FiShield, FiX } from 'react-icons/fi'
+import { getConsent, updateConsent } from '../../api/auth.js'
+import { useAuth } from '../../context/AuthContext.jsx'
+
+export default function ConsentBanner() {
+  const { isAuthenticated } = useAuth()
+  const qc = useQueryClient()
+  const [dismissed, setDismissed] = useState(false)
+
+  const { data } = useQuery({
+    queryKey: ['user-consent'],
+    queryFn: getConsent,
+    enabled: isAuthenticated,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const mutation = useMutation({
+    mutationFn: updateConsent,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['user-consent'] })
+      setDismissed(true)
+    },
+  })
+
+  // Don't show if not authenticated, already dismissed, or consent already set
+  if (!isAuthenticated || dismissed || !data?.consents) return null
+
+  const consents = data.consents
+  const hasDecided = Object.values(consents).some(c => c.granted || c.revoked_at)
+  if (hasDecided) return null
+
+  function handleAcceptAll() {
+    const payload = {}
+    for (const key of Object.keys(consents)) payload[key] = true
+    mutation.mutate(payload)
+  }
+
+  function handleDeclineAll() {
+    const payload = {}
+    for (const key of Object.keys(consents)) payload[key] = false
+    mutation.mutate(payload)
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 40 }}
+        transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+        className="fixed bottom-4 left-4 right-4 sm:left-auto sm:right-6 sm:bottom-6 sm:max-w-md z-50"
+      >
+        <div className="bg-white dark:bg-brand-900 border border-brand-200 dark:border-brand-700 rounded-2xl shadow-elevated p-5 space-y-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-accent-100 dark:bg-accent-900/30 flex items-center justify-center flex-shrink-0">
+                <FiShield size={16} className="text-accent-600 dark:text-accent-400" />
+              </div>
+              <h3 className="font-semibold text-sm text-brand-800 dark:text-brand-200">Data Usage Consent</h3>
+            </div>
+            <button
+              onClick={() => setDismissed(true)}
+              className="p-1 text-brand-400 hover:text-brand-600 dark:hover:text-brand-300 transition-colors"
+            >
+              <FiX size={16} />
+            </button>
+          </div>
+
+          <p className="text-xs text-brand-500 dark:text-brand-400 leading-relaxed">
+            OutfitAI would like to use your wardrobe data and preferences to improve our AI models and app experience.
+            You can review and change these settings anytime in <span className="font-medium text-brand-700 dark:text-brand-300">Settings &gt; Privacy</span>.
+          </p>
+
+          <div className="flex gap-2">
+            <button
+              onClick={handleDeclineAll}
+              disabled={mutation.isPending}
+              className="flex-1 h-9 rounded-xl border border-brand-200 dark:border-brand-700 text-sm font-medium text-brand-600 dark:text-brand-400 hover:bg-brand-50 dark:hover:bg-brand-800 transition-colors disabled:opacity-50"
+            >
+              Decline
+            </button>
+            <button
+              onClick={handleAcceptAll}
+              disabled={mutation.isPending}
+              className="flex-1 h-9 rounded-xl bg-accent-500 text-white text-sm font-medium hover:bg-accent-600 transition-colors disabled:opacity-50"
+            >
+              {mutation.isPending ? 'Saving...' : 'Accept All'}
+            </button>
+          </div>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/pages/ProfileSettingsPage.jsx
+++ b/frontend/src/pages/ProfileSettingsPage.jsx
@@ -1,9 +1,10 @@
 import { useState, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
-import { FiCamera, FiUser, FiSave, FiCheck, FiAlertCircle } from 'react-icons/fi'
+import { FiCamera, FiUser, FiSave, FiCheck, FiAlertCircle, FiShield, FiDownload, FiTrash2, FiLock } from 'react-icons/fi'
 import { getMyProfile, updateProfile, uploadAvatar } from '../api/social.js'
 import { getPersonPhoto, uploadPersonPhoto } from '../api/vto.js'
+import { getConsent, updateConsent, getPrivacySummary, exportData, deleteAccount, changePassword } from '../api/auth.js'
 import { useAuth } from '../context/AuthContext.jsx'
 import PageWrapper from '../components/layout/PageWrapper.jsx'
 import LoadingSpinner from '../components/ui/LoadingSpinner.jsx'
@@ -11,9 +12,10 @@ import LoadingSpinner from '../components/ui/LoadingSpinner.jsx'
 const API_URL = import.meta.env.VITE_API_URL || ''
 
 const TABS = [
-  { key: 'account',  label: 'Account Info' },
-  { key: 'avatar',   label: 'Profile Photo' },
-  { key: 'vto',      label: 'VTO Body Photo' },
+  { key: 'account',  label: 'Account' },
+  { key: 'avatar',   label: 'Photo' },
+  { key: 'vto',      label: 'VTO' },
+  { key: 'privacy',  label: 'Privacy' },
 ]
 
 export default function ProfileSettingsPage() {
@@ -58,6 +60,7 @@ export default function ProfileSettingsPage() {
         {tab === 'account'  && <AccountTab profile={profile} qc={qc} updateUser={updateUser} />}
         {tab === 'avatar'   && <AvatarTab  profile={profile} qc={qc} updateUser={updateUser} />}
         {tab === 'vto'      && <VtoTab />}
+        {tab === 'privacy'  && <PrivacyTab />}
       </div>
     </PageWrapper>
   )
@@ -371,6 +374,229 @@ function VtoTab() {
     </div>
   )
 }
+
+/* ── Privacy & Security tab ────────────────────────────────────────────── */
+
+function PrivacyTab() {
+  const { logoutUser } = useAuth()
+  const qc = useQueryClient()
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
+  const [deletePassword, setDeletePassword] = useState('')
+  const [deleteError, setDeleteError] = useState('')
+  const [pwForm, setPwForm] = useState({ current_password: '', new_password: '' })
+  const [pwSaved, setPwSaved] = useState(false)
+  const [pwError, setPwError] = useState('')
+
+  const { data: consentData, isLoading: consentLoading } = useQuery({
+    queryKey: ['user-consent'],
+    queryFn: getConsent,
+  })
+
+  const { data: privacyData, isLoading: privacyLoading } = useQuery({
+    queryKey: ['privacy-summary'],
+    queryFn: getPrivacySummary,
+  })
+
+  const consentMutation = useMutation({
+    mutationFn: updateConsent,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['user-consent'] }),
+  })
+
+  const exportMutation = useMutation({
+    mutationFn: exportData,
+    onSuccess: (data) => {
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `outfitai_data_export.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteAccount({ password: deletePassword }),
+    onSuccess: () => logoutUser(),
+    onError: (err) => setDeleteError(err?.response?.data?.error ?? 'Failed to delete account.'),
+  })
+
+  const pwMutation = useMutation({
+    mutationFn: () => changePassword(pwForm),
+    onSuccess: () => {
+      setPwSaved(true)
+      setPwError('')
+      setPwForm({ current_password: '', new_password: '' })
+      setTimeout(() => setPwSaved(false), 3000)
+    },
+    onError: (err) => setPwError(err?.response?.data?.error ?? 'Failed to change password.'),
+  })
+
+  if (consentLoading || privacyLoading) return <LoadingSpinner className="py-12" />
+
+  const consents = consentData?.consents || {}
+
+  return (
+    <div className="space-y-6">
+      {/* Data Consent */}
+      <div className="card p-6 space-y-5">
+        <div className="flex items-center gap-2 mb-1">
+          <FiShield size={18} className="text-accent-500" />
+          <h3 className="font-semibold text-brand-800 dark:text-brand-200">Data Usage Consent</h3>
+        </div>
+        <p className="text-sm text-brand-500 dark:text-brand-400">
+          Control how your data is used. You can change these at any time. Revoking consent does not delete your existing data.
+        </p>
+
+        {Object.entries(consents).map(([key, consent]) => (
+          <div key={key} className="flex items-start justify-between gap-4 py-3 border-t border-brand-100 dark:border-brand-800">
+            <div className="flex-1">
+              <p className="text-sm font-medium text-brand-800 dark:text-brand-200 capitalize">
+                {key.replace('_', ' ')}
+              </p>
+              <p className="text-xs text-brand-400 mt-0.5">{consent.description}</p>
+              {consent.granted && consent.granted_at && (
+                <p className="text-[10px] text-brand-300 mt-1">
+                  Granted: {new Date(consent.granted_at).toLocaleDateString()} (v{consent.version})
+                </p>
+              )}
+            </div>
+            <button
+              onClick={() => consentMutation.mutate({ [key]: !consent.granted })}
+              disabled={consentMutation.isPending}
+              className={`w-12 h-6 rounded-full transition-colors relative flex-shrink-0 mt-1 ${
+                consent.granted ? 'bg-accent-500' : 'bg-brand-300 dark:bg-brand-700'
+              }`}
+            >
+              <span className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-all ${
+                consent.granted ? 'left-7' : 'left-1'
+              }`} />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Data Summary */}
+      {privacyData && (
+        <div className="card p-6 space-y-4">
+          <h3 className="font-semibold text-brand-800 dark:text-brand-200">Your Data Summary</h3>
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              ['Wardrobe Items', privacyData.data_summary?.wardrobe_items],
+              ['Outfit History', privacyData.data_summary?.outfit_history],
+              ['Saved Outfits', privacyData.data_summary?.saved_outfits],
+              ['Feedback Given', privacyData.data_summary?.feedback_given],
+            ].map(([label, val]) => (
+              <div key={label} className="bg-brand-50 dark:bg-brand-900/40 rounded-xl p-3 text-center">
+                <p className="text-lg font-bold text-brand-800 dark:text-brand-200">{val ?? 0}</p>
+                <p className="text-[10px] text-brand-400 uppercase tracking-wider">{label}</p>
+              </div>
+            ))}
+          </div>
+
+          <button
+            onClick={() => exportMutation.mutate()}
+            disabled={exportMutation.isPending}
+            className="w-full btn-secondary h-10 rounded-2xl flex items-center justify-center gap-2 text-sm"
+          >
+            <FiDownload size={15} />
+            {exportMutation.isPending ? 'Preparing...' : 'Download My Data'}
+          </button>
+        </div>
+      )}
+
+      {/* Change Password */}
+      <div className="card p-6 space-y-4">
+        <div className="flex items-center gap-2 mb-1">
+          <FiLock size={16} className="text-brand-500" />
+          <h3 className="font-semibold text-brand-800 dark:text-brand-200">Change Password</h3>
+        </div>
+        <div className="space-y-3">
+          <input
+            type="password"
+            value={pwForm.current_password}
+            onChange={e => setPwForm(p => ({ ...p, current_password: e.target.value }))}
+            placeholder="Current password"
+            className="w-full px-4 py-3 rounded-2xl border border-brand-200 dark:border-brand-700 bg-white dark:bg-brand-900 text-brand-900 dark:text-brand-100 text-sm placeholder:text-brand-300 dark:placeholder:text-brand-600 focus:outline-none focus:ring-2 focus:ring-accent-400"
+          />
+          <input
+            type="password"
+            value={pwForm.new_password}
+            onChange={e => setPwForm(p => ({ ...p, new_password: e.target.value }))}
+            placeholder="New password (min 8 characters)"
+            className="w-full px-4 py-3 rounded-2xl border border-brand-200 dark:border-brand-700 bg-white dark:bg-brand-900 text-brand-900 dark:text-brand-100 text-sm placeholder:text-brand-300 dark:placeholder:text-brand-600 focus:outline-none focus:ring-2 focus:ring-accent-400"
+          />
+        </div>
+        {pwError && (
+          <div className="flex items-center gap-2 p-3 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 rounded-xl text-sm">
+            <FiAlertCircle size={15} /> {pwError}
+          </div>
+        )}
+        <button
+          onClick={() => { setPwError(''); pwMutation.mutate() }}
+          disabled={pwMutation.isPending || !pwForm.current_password || !pwForm.new_password}
+          className="w-full btn-primary h-10 rounded-2xl flex items-center justify-center gap-2 text-sm font-medium disabled:opacity-50"
+        >
+          {pwSaved ? <><FiCheck size={15} /> Password Changed</> : pwMutation.isPending ? 'Changing...' : 'Update Password'}
+        </button>
+      </div>
+
+      {/* Delete Account */}
+      <div className="card p-6 space-y-4 border-red-200 dark:border-red-900/40">
+        <div className="flex items-center gap-2">
+          <FiTrash2 size={16} className="text-red-500" />
+          <h3 className="font-semibold text-red-600 dark:text-red-400">Delete Account</h3>
+        </div>
+        <p className="text-sm text-brand-500 dark:text-brand-400">
+          Permanently delete your account and all associated data. This action cannot be undone.
+        </p>
+
+        {!deleteConfirm ? (
+          <button
+            onClick={() => setDeleteConfirm(true)}
+            className="w-full h-10 rounded-2xl border-2 border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 text-sm font-medium hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+          >
+            Delete My Account
+          </button>
+        ) : (
+          <div className="space-y-3 p-4 bg-red-50 dark:bg-red-900/10 rounded-2xl border border-red-200 dark:border-red-800/40">
+            <p className="text-sm font-medium text-red-700 dark:text-red-300">
+              Enter your password to confirm account deletion:
+            </p>
+            <input
+              type="password"
+              value={deletePassword}
+              onChange={e => { setDeletePassword(e.target.value); setDeleteError('') }}
+              placeholder="Your password"
+              className="w-full px-4 py-3 rounded-2xl border border-red-200 dark:border-red-700 bg-white dark:bg-brand-900 text-brand-900 dark:text-brand-100 text-sm focus:outline-none focus:ring-2 focus:ring-red-400"
+            />
+            {deleteError && (
+              <p className="text-sm text-red-600 dark:text-red-400 flex items-center gap-1">
+                <FiAlertCircle size={14} /> {deleteError}
+              </p>
+            )}
+            <div className="flex gap-2">
+              <button
+                onClick={() => { setDeleteConfirm(false); setDeletePassword(''); setDeleteError('') }}
+                className="flex-1 h-10 rounded-2xl border border-brand-200 dark:border-brand-700 text-sm font-medium text-brand-600 dark:text-brand-400 hover:bg-brand-50 dark:hover:bg-brand-800 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => deleteMutation.mutate()}
+                disabled={deleteMutation.isPending || !deletePassword}
+                className="flex-1 h-10 rounded-2xl bg-red-600 text-white text-sm font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
+              >
+                {deleteMutation.isPending ? 'Deleting...' : 'Confirm Delete'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 
 /* ── Shared ───────────────────────────────────────────────────────────────── */
 

--- a/migrations/versions/a1b2c3d4e5f6_add_audit_log_and_user_consents.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_audit_log_and_user_consents.py
@@ -1,0 +1,51 @@
+"""add_audit_log_and_user_consents
+
+Revision ID: a1b2c3d4e5f6
+Revises: 640f3d8513ce
+Create Date: 2026-04-06 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = '640f3d8513ce'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('audit_log',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('action', sa.String(length=50), nullable=False),
+        sa.Column('detail', sa.String(length=500), nullable=True),
+        sa.Column('ip_address', sa.String(length=45), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_audit_log_user_id', 'audit_log', ['user_id'])
+    op.create_index('ix_audit_log_action', 'audit_log', ['action'])
+    op.create_index('ix_audit_log_created_at', 'audit_log', ['created_at'])
+
+    op.create_table('user_consents',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('consent_type', sa.String(length=30), nullable=False),
+        sa.Column('granted', sa.Boolean(), nullable=False),
+        sa.Column('version', sa.String(length=10), nullable=False),
+        sa.Column('ip_address', sa.String(length=45), nullable=True),
+        sa.Column('granted_at', sa.DateTime(), nullable=True),
+        sa.Column('revoked_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_user_consents_user_id', 'user_consents', ['user_id'])
+    op.create_index('ix_consent_lookup', 'user_consents', ['user_id', 'consent_type'])
+
+
+def downgrade():
+    op.drop_table('user_consents')
+    op.drop_table('audit_log')

--- a/tests/test_flask_consent.py
+++ b/tests/test_flask_consent.py
@@ -1,0 +1,150 @@
+"""
+tests/test_flask_consent.py
+Tests for consent, privacy, password change, and account deletion endpoints.
+"""
+
+from __future__ import annotations
+
+
+class TestConsent:
+    def test_get_consent_defaults(self, client, auth_headers):
+        resp = client.get("/auth/consent", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "consents" in data
+        assert "data_training" in data["consents"]
+        assert "analytics" in data["consents"]
+        assert data["consents"]["data_training"]["granted"] is False
+        assert data["consents"]["analytics"]["granted"] is False
+
+    def test_grant_consent(self, client, auth_headers):
+        resp = client.patch(
+            "/auth/consent",
+            json={"data_training": True},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert "data_training" in resp.get_json()["updated"]
+
+        # Verify it persisted
+        resp2 = client.get("/auth/consent", headers=auth_headers)
+        assert resp2.get_json()["consents"]["data_training"]["granted"] is True
+
+    def test_revoke_consent(self, client, auth_headers):
+        client.patch("/auth/consent", json={"data_training": True}, headers=auth_headers)
+        resp = client.patch(
+            "/auth/consent",
+            json={"data_training": False},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        resp2 = client.get("/auth/consent", headers=auth_headers)
+        assert resp2.get_json()["consents"]["data_training"]["granted"] is False
+
+    def test_consent_invalid_type(self, client, auth_headers):
+        resp = client.patch(
+            "/auth/consent",
+            json={"invalid_type": True},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_consent_invalid_value(self, client, auth_headers):
+        resp = client.patch(
+            "/auth/consent",
+            json={"data_training": "yes"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_consent_requires_auth(self, client):
+        resp = client.get("/auth/consent")
+        assert resp.status_code == 401
+
+
+class TestPrivacySummary:
+    def test_privacy_summary(self, client, auth_headers):
+        resp = client.get("/auth/privacy-summary", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "data_summary" in data
+        assert "wardrobe_items" in data["data_summary"]
+        assert "email" in data
+
+
+class TestDataExport:
+    def test_data_export(self, client, auth_headers):
+        resp = client.get("/auth/data-export", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "user" in data
+        assert "wardrobe_items" in data
+        assert "consents" in data
+
+
+class TestChangePassword:
+    def test_change_password_success(self, client, auth_headers):
+        resp = client.post(
+            "/auth/change-password",
+            json={"current_password": "password123", "new_password": "newpass1234"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Can login with new password
+        resp2 = client.post(
+            "/auth/login",
+            json={"email": "test@example.com", "password": "newpass1234"},
+        )
+        assert resp2.status_code == 200
+
+    def test_change_password_wrong_current(self, client, auth_headers):
+        resp = client.post(
+            "/auth/change-password",
+            json={"current_password": "wrongpass", "new_password": "newpass1234"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 401
+
+    def test_change_password_too_short(self, client, auth_headers):
+        resp = client.post(
+            "/auth/change-password",
+            json={"current_password": "password123", "new_password": "short"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+
+class TestDeleteAccount:
+    def test_delete_account_success(self, client, auth_headers):
+        resp = client.delete(
+            "/auth/account",
+            json={"password": "password123"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert "deleted" in resp.get_json()["message"].lower()
+
+        # Can no longer login
+        resp2 = client.post(
+            "/auth/login",
+            json={"email": "test@example.com", "password": "password123"},
+        )
+        assert resp2.status_code == 401
+
+    def test_delete_account_wrong_password(self, client, auth_headers):
+        resp = client.delete(
+            "/auth/account",
+            json={"password": "wrongpass"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 401
+
+    def test_delete_account_no_password(self, client, auth_headers):
+        resp = client.delete(
+            "/auth/account",
+            json={},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- **Per-user rate limiting**: JWT identity for authenticated requests, IP fallback for public routes
- **Security headers**: CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy
- **Upload MIME validation**: Magic byte verification (PNG/JPEG signatures) before Pillow verify
- **Audit logging**: Immutable `audit_log` table tracking login, register, upload, delete, VTO jobs, consent changes, password changes
- **User data consent system**: Versioned consent tracking (data_training, analytics), grant/revoke with audit trail, GDPR-style data export, password change, account deletion with password confirmation
- **Privacy UI**: New "Privacy" tab in Settings with consent toggles, data summary dashboard, data export download, password change form, account deletion with confirmation
- **Consent banner**: Auto-shows for new users on first login, dismissible, links to Settings > Privacy
- **DB migration**: `audit_log` and `user_consents` tables with proper indexes

## Test plan
- [x] 44 backend tests pass (auth + errors + observability + 14 new consent tests)
- [x] Frontend builds successfully
- [ ] Browser: Register new account → consent banner appears at bottom
- [ ] Browser: Accept/decline consent → banner dismisses, settings reflect choice
- [ ] Browser: Settings > Privacy tab → toggle consents, download data, change password
- [ ] Browser: Delete account with wrong password → error shown
- [ ] Browser: Delete account with correct password → account removed, redirected to login
- [ ] Verify audit_log entries created for login, register, consent changes

Closes #11, closes #26