### PR TITLE
feat: migrate image storage to Supabase Storage

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.extensions import db, bcrypt, limiter
 from app.models_db import User, UserConsent, WardrobeItemDB, OutfitHistory, SavedOutfit, OutfitFeedback
 from app.audit import log_action
+from app.storage import get_public_url as _img_url
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -116,7 +117,7 @@ def login():
         "user_id":      user_id,
         "name":         name,
         "gender":       gender,
-        "avatar_url":   f"/uploads/{user.avatar_filename}" if user is not None and user.avatar_filename else None,
+        "avatar_url":   _img_url(user.avatar_filename) if user is not None and user.avatar_filename else None,
     }), 200
 
 

--- a/app/calendar/routes.py
+++ b/app/calendar/routes.py
@@ -21,6 +21,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app.extensions import db
 from app.models_db import OutfitPlan, SavedOutfit, WardrobeItemDB
+from app.storage import get_public_url as _img_url
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ def _fetch_plan_items(item_ids: list[int]) -> list[dict]:
     rows = WardrobeItemDB.query.filter(WardrobeItemDB.id.in_(item_ids)).all()
     item_map = {r.id: r for r in rows}
     return [
-        {"id": r.id, "category": r.category, "image_url": f"/uploads/{r.image_filename}"}
+        {"id": r.id, "category": r.category, "image_url": _img_url(r.image_filename)}
         for iid in item_ids
         if (r := item_map.get(iid))
     ]

--- a/app/config.py
+++ b/app/config.py
@@ -61,6 +61,9 @@ class Config:
     MAX_CONTENT_LENGTH       = 10 * 1024 * 1024   # 10 MB — Flask raises 413 on exceed
     UPLOAD_FOLDER            = "uploads"
     ALLOWED_EXTENSIONS       = {"jpg", "jpeg", "png"}
+    SUPABASE_URL             = os.environ.get("SUPABASE_URL", "")
+    SUPABASE_SERVICE_KEY     = os.environ.get("SUPABASE_SERVICE_KEY", "")
+    SUPABASE_BUCKET          = "wardrobe-images"
     MODEL1_PATH              = "models/model1_efficientnet_best.h5"
     MODEL2_PATH              = os.path.join("models", "model 2 Assets", "model2_compatibility_scorer.h5")
     # VTO engines (FASHN v1.5 = primary, IDM-VTON = fallback; both use HF Spaces)

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -12,6 +12,12 @@ import json
 from datetime import datetime, timezone
 
 from app.extensions import db
+from app.storage import get_public_url
+
+
+def _image_url(filename: str | None) -> str | None:
+    """Return Supabase CDN URL for a filename, or None."""
+    return get_public_url(filename) if filename else None
 
 
 # ── Junction table: post ↔ vibe (many-to-many) ────────────────────────────────
@@ -91,7 +97,7 @@ class User(db.Model):
             "follower_count":  self.follower_count,
             "following_count": self.following_count,
             "fusion_mode_enabled": self.fusion_mode_enabled,
-            "avatar_url": f"/uploads/{self.avatar_filename}" if self.avatar_filename else None,
+            "avatar_url": _image_url(self.avatar_filename),
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }
 
@@ -105,7 +111,7 @@ class User(db.Model):
             "follower_count": self.follower_count,
             "following_count": self.following_count,
             "is_public":      self.is_public,
-            "avatar_url":     f"/uploads/{self.avatar_filename}" if self.avatar_filename else None,
+            "avatar_url":     _image_url(self.avatar_filename),
         }
 
 
@@ -134,7 +140,7 @@ class WardrobeItemDB(db.Model):
             "sub_category":     self.sub_category,
             "formality":        self.formality,
             "gender":           self.gender,
-            "image_url":        image_url or f"/uploads/{self.image_filename}",
+            "image_url":        image_url or _image_url(self.image_filename),
             "model_confidence": self.model_confidence,
             "clip_confidence":  self.clip_confidence,
             "created_at":       self.created_at.isoformat() if self.created_at else None,
@@ -289,7 +295,7 @@ class SharedOutfit(db.Model):
             "user_id":     self.user_id,
             "user":        self.author.social_dict() if self.author else None,
             "caption":     self.caption,
-            "preview_url": f"/uploads/{self.preview_image_filename}" if self.preview_image_filename else None,
+            "preview_url": _image_url(self.preview_image_filename),
             "visibility":  self.visibility,
             "like_count":  self.like_count,
             "remix_count": self.remix_count,
@@ -391,7 +397,7 @@ class TryOnJob(db.Model):
             "id":         self.id,
             "item_id":    self.item_id,
             "status":     self.status,
-            "result_url": f"/uploads/{self.result_filename}" if self.result_filename else None,
+            "result_url": _image_url(self.result_filename),
             "error":      self.error_msg,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,

--- a/app/outfits/routes.py
+++ b/app/outfits/routes.py
@@ -21,6 +21,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app.extensions import db
 from app.models_db import OutfitHistory, OutfitFeedback, SavedOutfit, WardrobeItemDB
+from app.storage import get_public_url as _img_url
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ def _fetch_items_for_display(item_ids: list[int]) -> list[dict]:
             result.append({
                 "id":        row.id,
                 "category":  row.category,
-                "image_url": f"/uploads/{row.image_filename}",
+                "image_url": _img_url(row.image_filename),
             })
     return result
 

--- a/app/recommendations/routes.py
+++ b/app/recommendations/routes.py
@@ -23,6 +23,7 @@ from sqlalchemy import func
 from app.cache import recommendation_cache
 from app.extensions import db, limiter
 from app.models_db import User, WardrobeItemDB, OutfitHistory
+from app.storage import get_public_url as _img_url
 from app.utils import item_db_to_engine
 
 logger = logging.getLogger(__name__)
@@ -140,7 +141,7 @@ def _format_outfits_response(
             outfit_items.append({
                 "id":        eng_item.item_id,
                 "category":  eng_item.category.value,
-                "image_url": f"/uploads/{img_filename}",
+                "image_url": _img_url(img_filename),
             })
         formatted_outfits.append({
             "rank":           rank,
@@ -433,7 +434,7 @@ def outfit_of_the_day():
         outfit_items.append({
             "id":        eng_item.item_id,
             "category":  eng_item.category.value,
-            "image_url": f"/uploads/{img_filename}",
+            "image_url": _img_url(img_filename),
         })
 
     outfit_item_ids = {item.item_id for item in best_outfit.items}
@@ -645,7 +646,7 @@ def _generate_swap_suggestions(
                         "remove_item_category": item.category.value if hasattr(item.category, 'value') else item.category,
                         "add_item_id": alt.item_id,
                         "add_item_category": cat_val,
-                        "add_item_image": f"/uploads/{img_fn}" if img_fn else None,
+                        "add_item_image": _img_url(img_fn) if img_fn else None,
                         "score_delta": round(delta, 4),
                         "new_score": round(trial_result.final_score, 4),
                     })

--- a/app/social/routes.py
+++ b/app/social/routes.py
@@ -62,6 +62,7 @@ from app.models_db import (
     SavedOutfit, SharedOutfit, User, VibeTag, WardrobeItemDB,
     post_vibes,
 )
+from app.storage import get_public_url as _img_url
 from app.utils import allowed_file, validate_image_content
 
 logger = logging.getLogger(__name__)
@@ -176,7 +177,7 @@ def _post_to_dict(post: SharedOutfit, viewer_id: int | None) -> dict:
         thumb_items = WardrobeItemDB.query.filter(WardrobeItemDB.id.in_(item_ids[:6])).all()
         thumb_map   = {i.id: i for i in thumb_items}
         item_images = [
-            f"/uploads/{thumb_map[iid].image_filename}"
+            _img_url(thumb_map[iid].image_filename)
             for iid in item_ids[:6]
             if iid in thumb_map and thumb_map[iid].image_filename
         ]
@@ -310,19 +311,29 @@ def upload_avatar():
                 os.remove(old_path)
         except OSError:
             pass
+        from app.storage import delete_file as storage_delete
+        storage_delete(user.avatar_filename)
 
     ext = file.filename.rsplit(".", 1)[1].lower()
     filename = f"avatar_{user_id}_{uuid.uuid4().hex[:12]}.{ext}"
     upload_dir = current_app.config["UPLOAD_FOLDER"]
     os.makedirs(upload_dir, exist_ok=True)
-    with open(os.path.join(upload_dir, filename), "wb") as f:
+    save_path = os.path.join(upload_dir, filename)
+    with open(save_path, "wb") as f:
         f.write(content)
+
+    # Upload to Supabase Storage
+    try:
+        from app.storage import upload_file_from_path
+        upload_file_from_path(save_path, filename)
+    except Exception as exc:
+        logger.warning("Supabase upload failed for %s: %s", filename, exc)
 
     user.avatar_filename = filename
     db.session.commit()
 
     return jsonify({
-        "avatar_url": f"/uploads/{filename}",
+        "avatar_url": _img_url(filename),
     }), 200
 
 
@@ -608,6 +619,12 @@ def publish_outfit():
         ok = generate_outfit_preview(image_paths, preview_path)
         if ok:
             post.preview_image_filename = preview_filename
+            # Upload preview to Supabase
+            try:
+                from app.storage import upload_file_from_path
+                upload_file_from_path(preview_path, preview_filename)
+            except Exception as exc2:
+                logger.warning("Supabase upload failed for preview %s: %s", preview_filename, exc2)
     except Exception as exc:
         logger.warning("Preview generation failed for post %s: %s", post.id, exc)
 
@@ -615,7 +632,7 @@ def publish_outfit():
 
     return jsonify({
         "id":          post.id,
-        "preview_url": f"/uploads/{post.preview_image_filename}" if post.preview_image_filename else None,
+        "preview_url": _img_url(post.preview_image_filename) if post.preview_image_filename else None,
         "caption":     post.caption,
         "vibes":       [v.to_dict() for v in post.vibes],
         "visibility":  post.visibility,
@@ -662,7 +679,7 @@ def get_post(post_id: int):
             {
                 "id":           item_map[iid].id,
                 "category":     item_map[iid].category,
-                "image_url":    f"/uploads/{item_map[iid].image_filename}",
+                "image_url":    _img_url(item_map[iid].image_filename),
                 "sub_category": item_map[iid].sub_category,
             }
             for iid in item_ids if iid in item_map
@@ -976,7 +993,7 @@ def remix_post(post_id: int):
             src_info = {
                 "id":           src_item.id,
                 "category":     src_item.category,
-                "image_url":    f"/uploads/{src_item.image_filename}",
+                "image_url":    _img_url(src_item.image_filename),
                 "sub_category": src_item.sub_category,
             }
         candidates_out = [

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,112 @@
+"""
+app/storage.py
+Supabase Storage helper — upload, download, delete, URL generation.
+Uses requests directly (no SDK dependency).
+"""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+
+import requests
+from flask import current_app
+
+logger = logging.getLogger(__name__)
+
+
+def _cfg():
+    """Return (url, key, bucket) from Flask config."""
+    return (
+        current_app.config.get("SUPABASE_URL", ""),
+        current_app.config.get("SUPABASE_SERVICE_KEY", ""),
+        current_app.config.get("SUPABASE_BUCKET", "wardrobe-images"),
+    )
+
+
+def is_configured() -> bool:
+    """True when Supabase Storage env vars are set."""
+    try:
+        url, key, _ = _cfg()
+        return bool(url and key)
+    except RuntimeError:
+        # Outside Flask app context (e.g. tests)
+        return bool(
+            os.environ.get("SUPABASE_URL") and os.environ.get("SUPABASE_SERVICE_KEY")
+        )
+
+
+def get_public_url(filename: str) -> str:
+    """Build public CDN URL for a file. No network call."""
+    try:
+        url, _, bucket = _cfg()
+    except RuntimeError:
+        url = os.environ.get("SUPABASE_URL", "")
+        bucket = "wardrobe-images"
+    if not url:
+        return f"/uploads/{filename}"
+    return f"{url}/storage/v1/object/public/{bucket}/{filename}"
+
+
+def upload_file(filename: str, file_bytes: bytes, content_type: str = "image/png") -> str:
+    """Upload bytes to Supabase Storage. Returns public URL on success."""
+    url, key, bucket = _cfg()
+    if not url or not key:
+        logger.debug("Supabase not configured, skipping upload for %s", filename)
+        return f"/uploads/{filename}"
+
+    endpoint = f"{url}/storage/v1/object/{bucket}/{filename}"
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": content_type,
+        "x-upsert": "true",
+    }
+    try:
+        resp = requests.post(endpoint, headers=headers, data=file_bytes, timeout=30)
+        resp.raise_for_status()
+        logger.info("Uploaded %s to Supabase (%d bytes)", filename, len(file_bytes))
+        return get_public_url(filename)
+    except requests.RequestException as exc:
+        logger.warning("Supabase upload failed for %s: %s", filename, exc)
+        return f"/uploads/{filename}"
+
+
+def upload_file_from_path(filepath: str, filename: str) -> str:
+    """Read a local file and upload it to Supabase Storage."""
+    content_type = mimetypes.guess_type(filepath)[0] or "image/png"
+    with open(filepath, "rb") as f:
+        return upload_file(filename, f.read(), content_type)
+
+
+def download_file(filename: str) -> bytes | None:
+    """Download a file from Supabase public URL. Returns bytes or None."""
+    public_url = get_public_url(filename)
+    if not public_url.startswith("http"):
+        return None
+    try:
+        resp = requests.get(public_url, timeout=30)
+        resp.raise_for_status()
+        return resp.content
+    except requests.RequestException as exc:
+        logger.warning("Supabase download failed for %s: %s", filename, exc)
+        return None
+
+
+def delete_file(filename: str) -> bool:
+    """Delete a file from Supabase Storage."""
+    url, key, bucket = _cfg()
+    if not url or not key:
+        return False
+
+    endpoint = f"{url}/storage/v1/object/{bucket}/{filename}"
+    headers = {"Authorization": f"Bearer {key}"}
+    try:
+        resp = requests.delete(endpoint, headers=headers, timeout=15)
+        if resp.status_code in (200, 204, 404):
+            return True
+        resp.raise_for_status()
+        return True
+    except requests.RequestException as exc:
+        logger.warning("Supabase delete failed for %s: %s", filename, exc)
+        return False

--- a/app/vto/routes.py
+++ b/app/vto/routes.py
@@ -69,7 +69,8 @@ def _get_daily_usage(user_id: int) -> int:
 
 
 def _person_photo_url(filename: str) -> str:
-    return f"/uploads/{filename}"
+    from app.storage import get_public_url
+    return get_public_url(filename)
 
 
 def _extract_output_source(output) -> str:
@@ -156,6 +157,8 @@ def upload_person_photo():
                 os.remove(old_path)
         except OSError as exc:
             logger.warning("Could not delete old person photo %s: %s", old_path, exc)
+        from app.storage import delete_file as storage_delete
+        storage_delete(user.profile_photo_filename)
 
         # Invalidate all existing try-on jobs for this user — person photo changed
         TryOnJob.query.filter_by(user_id=user_id).delete()
@@ -170,6 +173,13 @@ def upload_person_photo():
 
     with open(save_path, "wb") as f:
         f.write(content)
+
+    # Upload to Supabase Storage
+    try:
+        from app.storage import upload_file_from_path
+        upload_file_from_path(save_path, filename)
+    except Exception as exc:
+        logger.warning("Supabase upload failed for %s: %s", filename, exc)
 
     user.profile_photo_filename = filename
     db.session.commit()
@@ -248,19 +258,32 @@ def submit_tryon():
         }), 422
 
     upload_dir = current_app.config["UPLOAD_FOLDER"]
+    os.makedirs(upload_dir, exist_ok=True)
     person_path = os.path.join(upload_dir, user.profile_photo_filename)
     if not os.path.exists(person_path):
-        # File missing — clear stale reference
-        user.profile_photo_filename = None
-        db.session.commit()
-        return jsonify({
-            "error":       "Person photo file not found. Please re-upload.",
-            "needs_photo": True,
-        }), 422
+        # Try downloading from Supabase (ephemeral disk may have lost the file)
+        from app.storage import download_file
+        data = download_file(user.profile_photo_filename)
+        if data:
+            with open(person_path, "wb") as f:
+                f.write(data)
+        else:
+            user.profile_photo_filename = None
+            db.session.commit()
+            return jsonify({
+                "error":       "Person photo file not found. Please re-upload.",
+                "needs_photo": True,
+            }), 422
 
     garment_path = os.path.join(upload_dir, item.image_filename)
     if not os.path.exists(garment_path):
-        return jsonify({"error": "Garment image file not found."}), 500
+        from app.storage import download_file
+        data = download_file(item.image_filename)
+        if data:
+            with open(garment_path, "wb") as f:
+                f.write(data)
+        else:
+            return jsonify({"error": "Garment image file not found."}), 500
 
     # ── Compute cache key ─────────────────────────────────────────────────────
     with open(person_path, "rb") as f:
@@ -442,6 +465,13 @@ def _run_tryon_job(
                         raise FileNotFoundError(f"FASHN output path not found: {source_str}")
                     shutil.copy(source_str, result_path)
 
+                # Upload result to Supabase
+                try:
+                    from app.storage import upload_file_from_path
+                    upload_file_from_path(result_path, result_filename)
+                except Exception as exc:
+                    logger.warning("Supabase upload failed for %s: %s", result_filename, exc)
+
                 job.status          = "ready"
                 job.result_filename = result_filename
                 job.completed_at    = datetime.now(timezone.utc)
@@ -520,6 +550,13 @@ def _run_tryon_job(
                 result_filename = f"tryon_{job_id}_{uuid.uuid4().hex[:8]}.png"
                 result_path     = os.path.join(upload_dir, result_filename)
                 shutil.copy(result_source, result_path)
+
+                # Upload result to Supabase
+                try:
+                    from app.storage import upload_file_from_path
+                    upload_file_from_path(result_path, result_filename)
+                except Exception as exc:
+                    logger.warning("Supabase upload failed for %s: %s", result_filename, exc)
 
                 job.status          = "ready"
                 job.result_filename = result_filename

--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -25,7 +25,7 @@ import os
 import uuid
 
 from flask import (
-    Blueprint, current_app, jsonify, request, send_from_directory,
+    Blueprint, current_app, jsonify, redirect, request, send_from_directory,
 )
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
@@ -215,7 +215,14 @@ def upload_item():
     recommendation_cache.invalidate_user(user_id)
     log_action("upload_item", user_id=user_id, detail=f"item_id={item.id} category={category}")
 
-    # ── 9. Return with upload guidance ────────────────────────────────────────
+    # ── 9. Upload to Supabase Storage ────────────────────────────────────────
+    try:
+        from app.storage import upload_file_from_path
+        upload_file_from_path(save_path, filename)
+    except Exception as exc:
+        logger.warning("Supabase upload failed for %s: %s", filename, exc)
+
+    # ── 10. Return with upload guidance ───────────────────────────────────────
     return jsonify({**item.to_dict(), "tips": UPLOAD_TIPS, "bg_removed": bg_removed}), 201
 
 
@@ -250,13 +257,15 @@ def delete_item(item_id: int):
     if item.user_id != user_id:
         return jsonify({"error": "Access forbidden."}), 403
 
-    # Delete image file — log but don't fail if file is already gone
+    # Delete image file from local disk and Supabase
     image_path = os.path.join(current_app.config["UPLOAD_FOLDER"], item.image_filename)
     try:
         if os.path.exists(image_path):
             os.remove(image_path)
     except OSError as exc:
         logger.warning("Could not delete image file %s: %s", image_path, exc)
+    from app.storage import delete_file as storage_delete
+    storage_delete(item.image_filename)
 
     db.session.delete(item)
     db.session.commit()
@@ -429,21 +438,13 @@ def wardrobe_stats():
 def serve_upload(filename: str):
     """
     GET /uploads/<filename>
-    Serves uploaded images publicly (no auth required).
-    Returns 404 if the filename is not in the database.
+    Redirects to Supabase CDN when configured, otherwise serves from local disk.
     """
-    # Check wardrobe items, then user photos (avatar / VTO person photo)
-    is_known = WardrobeItemDB.query.filter_by(image_filename=filename).first() is not None
-    if not is_known:
-        is_known = User.query.filter(
-            (User.avatar_filename == filename) |
-            (User.profile_photo_filename == filename)
-        ).first() is not None
-    if not is_known:
-        # Also allow shared-outfit preview images and try-on results (prefix check)
-        is_known = filename.startswith(("preview_", "person_", "avatar_", "tryon_"))
-    if not is_known:
-        return jsonify({"error": "File not found."}), 404
+    from app.storage import is_configured, get_public_url
 
+    if is_configured():
+        return redirect(get_public_url(filename), code=302)
+
+    # Fallback for local dev without Supabase
     upload_dir = current_app.config["UPLOAD_FOLDER"]
     return send_from_directory(os.path.abspath(upload_dir), filename)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,39 +2,10 @@
 set -e
 
 echo "Starting OutfitAI..."
-echo "Memory info:"
-free -m 2>/dev/null || cat /proc/meminfo 2>/dev/null | head -5 || echo "(no mem info)"
-echo "Disk info:"
-df -h /app 2>/dev/null | tail -1 || echo "(no disk info)"
 echo "Python version: $(python --version 2>&1)"
 
-# ── Persistent Storage Setup (Hugging Face Buckets) ──────────────────────────
-# If the /data bucket is mounted, symlink uploads/ and instance/ there.
-# This ensures images and the database persist across restarts.
-if [ -d "/data" ]; then
-    echo "Found /data bucket. Setting up persistence..."
-    
-    # 1. Prepare Storage Subdirectories
-    mkdir -p /data/uploads /data/instance
-    
-    # 2. Bridge uploads/ (Items, Avatars, Try-On results)
-    if [ -d "/app/uploads" ] && [ ! -L "/app/uploads" ]; then
-        echo "Linking /app/uploads to /data/uploads..."
-        cp -rn /app/uploads/. /data/uploads/ 2>/dev/null || true
-        rm -rf /app/uploads
-        ln -s /data/uploads /app/uploads
-    fi
-    
-    # 3. Bridge instance/ (Local DB fallback)
-    if [ -d "/app/instance" ] && [ ! -L "/app/instance" ]; then
-        echo "Linking /app/instance to /data/instance..."
-        cp -rn /app/instance/. /data/instance/ 2>/dev/null || true
-        rm -rf /app/instance
-        ln -s /data/instance /app/instance
-    fi
-else
-    echo "Warning: /data bucket not found. Files will be ephemeral (deleted on restart)."
-fi
+# Temp workspace for image processing (atelier, VTO, preview generation)
+mkdir -p /app/uploads /app/instance
 
 # Run Flask migrations
 echo "Running database migrations..."

--- a/frontend/src/api/wardrobe.js
+++ b/frontend/src/api/wardrobe.js
@@ -17,5 +17,8 @@ export const patchItem = (id, data) =>
 export const getWardrobeStats = () =>
   api.get('/wardrobe/stats').then(r => r.data)
 
-export const getImageUrl = (filename) =>
-  `${import.meta.env.VITE_API_URL || ''}/uploads/${filename}`
+export const getImageUrl = (filename) => {
+  if (!filename) return null
+  if (filename.startsWith('http')) return filename
+  return `${import.meta.env.VITE_API_URL || ''}/uploads/${filename}`
+}

--- a/frontend/src/components/calendar/CalendarGrid.jsx
+++ b/frontend/src/components/calendar/CalendarGrid.jsx
@@ -1,7 +1,6 @@
 import { motion } from 'framer-motion'
 import { FiBriefcase, FiSun, FiHeart } from 'react-icons/fi'
-
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../../utils/resolveUrl.js'
 const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 const OCCASION_ICON = {
@@ -88,7 +87,7 @@ export default function CalendarGrid({ year, month, plans, onDayClick }) {
                     {plan.items?.slice(0, 2).map((item, j) => (
                       <div key={j} className="w-4 h-4 sm:w-5 sm:h-5 rounded overflow-hidden bg-brand-100 dark:bg-brand-800 flex-shrink-0">
                         {item.image_url && (
-                          <img src={`${API_URL}${item.image_url}`} alt="" className="w-full h-full object-cover" />
+                          <img src={resolveUrl(item.image_url)} alt="" className="w-full h-full object-cover" />
                         )}
                       </div>
                     ))}

--- a/frontend/src/components/calendar/PlanModal.jsx
+++ b/frontend/src/components/calendar/PlanModal.jsx
@@ -7,8 +7,7 @@ import { getSaved } from '../../api/outfits.js'
 import { getItems } from '../../api/wardrobe.js'
 import { createPlan, updatePlan, deletePlan } from '../../api/calendar.js'
 import ConfirmDialog from '../ui/ConfirmDialog.jsx'
-
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../../utils/resolveUrl.js'
 
 const OCCASIONS = [
   { val: 'casual', label: 'Casual', Icon: FiSun },
@@ -239,7 +238,7 @@ export default function PlanModal({ open, date, existingPlan, monthStr, onClose 
                         <div className="flex gap-0.5 flex-shrink-0">
                           {outfit.items?.slice(0, 3).map((item, j) => (
                             <div key={j} className="w-8 h-8 rounded-lg overflow-hidden bg-brand-100 dark:bg-brand-800">
-                              {item.image_url && <img src={`${API_URL}${item.image_url}`} alt="" className="w-full h-full object-cover" />}
+                              {item.image_url && <img src={resolveUrl(item.image_url)} alt="" className="w-full h-full object-cover" />}
                             </div>
                           ))}
                         </div>
@@ -268,7 +267,7 @@ export default function PlanModal({ open, date, existingPlan, monthStr, onClose 
                               : 'border-brand-100/60 dark:border-brand-800/40 hover:border-brand-300 dark:hover:border-brand-600'
                           }`}
                         >
-                          {item.image_url && <img src={`${API_URL}${item.image_url}`} alt={item.category} className="w-full h-full object-cover" />}
+                          {item.image_url && <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />}
                           {selected && (
                             <div className="absolute top-1 right-1 w-5 h-5 bg-accent-500 rounded-full flex items-center justify-center shadow-sm">
                               <FiCheck size={12} className="text-white" />

--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -7,8 +7,7 @@ import { getOOTD } from '../../api/recommendations.js'
 import { saveOutfit } from '../../api/outfits.js'
 import { scoreToPercent } from '../../utils/formatters.js'
 import ConfidenceBadge from '../ui/ConfidenceBadge.jsx'
-
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../../utils/resolveUrl.js'
 
 export default function OOTDWidget() {
   const [saved, setSaved] = useState(false)
@@ -137,7 +136,7 @@ export default function OOTDWidget() {
             >
               <div className="w-20 h-20 rounded-xl overflow-hidden bg-brand-100/60 dark:bg-brand-800/40 border border-brand-100/60 dark:border-brand-700/40 shadow-sm">
                 {item.image_url && (
-                  <img src={`${API_URL}${item.image_url}`} alt={item.category} loading="lazy" decoding="async" className="w-full h-full object-cover" />
+                  <img src={resolveUrl(item.image_url)} alt={item.category} loading="lazy" decoding="async" className="w-full h-full object-cover" />
                 )}
               </div>
               <p className="text-[11px] text-brand-500 dark:text-brand-400 text-center mt-1.5 capitalize">{item.category}</p>

--- a/frontend/src/components/layout/Navbar.jsx
+++ b/frontend/src/components/layout/Navbar.jsx
@@ -4,8 +4,7 @@ import { useAuth } from '../../context/AuthContext.jsx'
 import { motion, AnimatePresence } from 'framer-motion'
 import { FiHome, FiGrid, FiStar, FiCalendar, FiBookmark, FiClock, FiLogOut, FiEdit3, FiMenu, FiX, FiUsers, FiSettings } from 'react-icons/fi'
 import ThemeToggle from '../ui/ThemeToggle.jsx'
-
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../../utils/resolveUrl.js'
 
 const NAV_LINKS = [
   { to: '/dashboard',       label: 'Dashboard', Icon: FiHome },
@@ -96,7 +95,7 @@ export default function Navbar() {
               >
                 {user?.avatar_url && !avatarError ? (
                   <img
-                    src={`${API_URL}${user.avatar_url}`}
+                    src={resolveUrl(user.avatar_url)}
                     alt=""
                     className="w-full h-full object-cover"
                     onError={() => setAvatarError(true)}

--- a/frontend/src/components/social/FeedCard.jsx
+++ b/frontend/src/components/social/FeedCard.jsx
@@ -7,8 +7,7 @@ import { toggleLike, toggleBookmark, deletePost } from '../../api/social.js'
 import VibeTagPill from './VibeTagPill.jsx'
 import ConfirmDialog from '../ui/ConfirmDialog.jsx'
 import { useAuth } from '../../context/AuthContext.jsx'
-
-const BASE = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../../utils/resolveUrl.js'
 
 export default function FeedCard({ post, onRemixClick, onVibeClick, onPostClick }) {
   const { user } = useAuth()
@@ -59,7 +58,7 @@ export default function FeedCard({ post, onRemixClick, onVibeClick, onPostClick 
     },
   })
 
-  const previewUrl  = post.preview_url ? `${BASE}${post.preview_url}` : null
+  const previewUrl  = post.preview_url ? resolveUrl(post.preview_url) : null
   const itemImages  = post.outfit?.item_images ?? []
   const username    = post.user?.username || `user_${post.user_id}`
   const timeAgo     = _timeAgo(post.created_at)
@@ -114,7 +113,7 @@ export default function FeedCard({ post, onRemixClick, onVibeClick, onPostClick 
             >
               <div className="w-6 h-6 rounded-full overflow-hidden bg-brand-200 dark:bg-brand-700 flex-shrink-0 flex items-center justify-center text-[10px] font-bold text-brand-600 dark:text-brand-300">
                 {post.user?.avatar_url ? (
-                  <img src={`${BASE}${post.user.avatar_url}`} alt="" className="w-full h-full object-cover" />
+                  <img src={resolveUrl(post.user.avatar_url)} alt="" className="w-full h-full object-cover" />
                 ) : (
                   (post.user?.name?.[0] || username[0]).toUpperCase()
                 )}
@@ -250,7 +249,7 @@ function ItemMosaic({ images, occasion, score }) {
             }`}
           >
             <img
-              src={`${BASE}${url}`}
+              src={resolveUrl(url)}
               alt=""
               loading="lazy"
               decoding="async"

--- a/frontend/src/components/social/PostDetailModal.jsx
+++ b/frontend/src/components/social/PostDetailModal.jsx
@@ -7,8 +7,7 @@ import { getPost, toggleLike, toggleBookmark, followUser, unfollowUser } from '.
 import { useAuth } from '../../context/AuthContext.jsx'
 import VibeTagPill from './VibeTagPill.jsx'
 import OutfitTryOnModal from '../tryon/OutfitTryOnModal.jsx'
-
-const BASE = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../../utils/resolveUrl.js'
 
 export default function PostDetailModal({ post, open, onClose, onRemixClick, onVibeClick }) {
   const { user } = useAuth()
@@ -33,7 +32,7 @@ export default function PostDetailModal({ post, open, onClose, onRemixClick, onV
   const [tryOnOpen,   setTryOnOpen]  = useState(false)
 
   const isOwn = user?.id === p?.user_id
-  const previewUrl = p?.preview_url ? `${BASE}${p.preview_url}` : null
+  const previewUrl = p?.preview_url ? resolveUrl(p.preview_url) : null
   const username = p?.user?.username || `user_${p?.user_id}`
 
   // Collect item images — from full post items OR from outfit.item_images
@@ -108,7 +107,7 @@ export default function PostDetailModal({ post, open, onClose, onRemixClick, onV
                   >
                     <div className="w-8 h-8 rounded-full overflow-hidden bg-brand-200 dark:bg-brand-700 flex-shrink-0 flex items-center justify-center text-xs font-bold text-brand-600 dark:text-brand-300">
                       {p?.user?.avatar_url ? (
-                        <img src={`${BASE}${p.user.avatar_url}`} alt="" className="w-full h-full object-cover" />
+                        <img src={resolveUrl(p.user.avatar_url)} alt="" className="w-full h-full object-cover" />
                       ) : (
                         (p?.user?.name?.[0] || username[0]).toUpperCase()
                       )}
@@ -164,7 +163,7 @@ export default function PostDetailModal({ post, open, onClose, onRemixClick, onV
                     {fullPost.items.map((item, i) => (
                       <div key={i} className="aspect-square rounded-lg overflow-hidden bg-brand-100 dark:bg-brand-800 border border-brand-200 dark:border-brand-700">
                         {item.image_url ? (
-                          <img src={`${BASE}${item.image_url}`} alt={item.category} className="w-full h-full object-cover" />
+                          <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />
                         ) : (
                           <div className="w-full h-full flex items-center justify-center text-xl opacity-30">
                             <span className="select-none">?</span>
@@ -278,7 +277,7 @@ function ModalMosaic({ images, occasion, score }) {
             }`}
           >
             <img
-              src={`${BASE}${url}`}
+              src={resolveUrl(url)}
               alt=""
               className="absolute inset-0 w-full h-full object-cover"
               onError={e => { e.currentTarget.style.display = 'none' }}

--- a/frontend/src/components/social/RemixResultModal.jsx
+++ b/frontend/src/components/social/RemixResultModal.jsx
@@ -5,8 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { FiX, FiArrowRight, FiRefreshCw, FiAlertCircle } from 'react-icons/fi'
 import { remixPost } from '../../api/social.js'
 import PublishModal from './PublishModal.jsx'
-
-const BASE = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../../utils/resolveUrl.js'
 
 export default function RemixResultModal({ open, onClose, post }) {
   const navigate = useNavigate()
@@ -134,7 +133,7 @@ export default function RemixResultModal({ open, onClose, post }) {
                             <div className="w-16 h-16 rounded-lg bg-brand-100 dark:bg-brand-800 overflow-hidden">
                               {match.source_item?.image_url ? (
                                 <img
-                                  src={`${BASE}${match.source_item.image_url}`}
+                                  src={resolveUrl(match.source_item.image_url)}
                                   className="w-full h-full object-cover"
                                   alt=""
                                 />
@@ -167,7 +166,7 @@ export default function RemixResultModal({ open, onClose, post }) {
                                   }`}
                                 >
                                   <img
-                                    src={`${BASE}${c.image_url}`}
+                                    src={resolveUrl(c.image_url)}
                                     className="w-full h-full object-cover"
                                     alt=""
                                     onError={e => { e.target.style.display = 'none' }}

--- a/frontend/src/components/tryon/OutfitTryOnModal.jsx
+++ b/frontend/src/components/tryon/OutfitTryOnModal.jsx
@@ -3,8 +3,7 @@ import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { FiX, FiUser } from 'react-icons/fi'
 import TryOnModal from './TryOnModal.jsx'
-
-const API_BASE = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../../utils/resolveUrl.js'
 
 // Hero priority — most visually impactful garments first
 const HERO_PRIORITY = ['dress', 'jumpsuit', 'top', 'outwear', 'bottom', 'shoes']
@@ -86,7 +85,7 @@ export default function OutfitTryOnModal({ open, onClose, items, occasion }) {
             <div className="grid grid-cols-3 gap-3 mb-6">
               {tryableItems.map((item) => {
                 const isActive = active?.id === item.id
-                const imgUrl = `${API_BASE}${item.image_url}`
+                const imgUrl = resolveUrl(item.image_url)
 
                 return (
                   <button

--- a/frontend/src/components/tryon/TryOnModal.jsx
+++ b/frontend/src/components/tryon/TryOnModal.jsx
@@ -5,8 +5,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { FiX, FiUploadCloud, FiUser, FiRefreshCw, FiCheck, FiAlertTriangle, FiDownload } from 'react-icons/fi'
 import { getPersonPhoto, uploadPersonPhoto, submitTryOn, getJobStatus } from '../../api/vto.js'
 import LoadingSpinner from '../ui/LoadingSpinner.jsx'
+import { resolveUrl } from '../../utils/resolveUrl.js'
 
-const API_BASE = import.meta.env.VITE_API_URL || ''
 const POLL_INTERVAL_MS = 3000
 
 export default function TryOnModal({ open, onClose, item }) {
@@ -138,8 +138,8 @@ export default function TryOnModal({ open, onClose, item }) {
 
   if (!open || !item) return null
 
-  const itemImageUrl = item.image_url ? `${API_BASE}${item.image_url}` : null
-  const personPhotoUrl = photoData?.photo_url ? `${API_BASE}${photoData.photo_url}` : null
+  const itemImageUrl = item.image_url ? resolveUrl(item.image_url) : null
+  const personPhotoUrl = photoData?.photo_url ? resolveUrl(photoData?.photo_url) : null
 
   return createPortal(
     <AnimatePresence>
@@ -398,7 +398,7 @@ export default function TryOnModal({ open, onClose, item }) {
               <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
                 <div className="mb-4 rounded-2xl overflow-hidden border border-brand-200/60 dark:border-brand-700/40 shadow-md bg-white dark:bg-brand-800">
                   <img
-                    src={`${API_BASE}${result}`}
+                    src={resolveUrl(result)}
                     alt="Virtual try-on result"
                     className="w-full object-contain max-h-[50vh]"
                   />
@@ -412,7 +412,7 @@ export default function TryOnModal({ open, onClose, item }) {
                 <div className="flex gap-3">
                   <button onClick={onClose} className="flex-1 btn-secondary">Close</button>
                   <a
-                    href={`${API_BASE}${result}`}
+                    href={resolveUrl(result)}
                     download={`tryon_${item.category}.png`}
                     className="flex-1 btn-primary text-center flex items-center justify-center gap-2"
                   >

--- a/frontend/src/pages/OutfitEditorPage.jsx
+++ b/frontend/src/pages/OutfitEditorPage.jsx
@@ -14,8 +14,7 @@ import ConfidenceBadge from '../components/ui/ConfidenceBadge.jsx'
 import CustomSelect from '../components/ui/CustomSelect.jsx'
 import { scoreToPercent } from '../utils/formatters.js'
 import OutfitTryOnModal from '../components/tryon/OutfitTryOnModal.jsx'
-
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../utils/resolveUrl.js'
 
 const CAT_EMOJI = { top: '👕', bottom: '👖', outwear: '🧥', shoes: '👟', dress: '👗', jumpsuit: '🧘' }
 const CATEGORIES = ['all', 'top', 'bottom', 'outwear', 'shoes', 'dress', 'jumpsuit']
@@ -228,7 +227,7 @@ export default function OutfitEditorPage() {
                 >
                   <div className="aspect-square rounded-2xl overflow-hidden bg-brand-50/60 dark:bg-brand-800/40 border border-brand-100/60 dark:border-brand-700/40 group-hover:border-accent-400 transition-all duration-300 relative shadow-sm">
                     {item.image_url ? (
-                      <img src={`${API_URL}${item.image_url}`} alt={item.category} className="w-full h-full object-cover" />
+                      <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />
                     ) : (
                       <div className="w-full h-full flex items-center justify-center text-2xl opacity-40 grayscale">
                         {CAT_EMOJI[item.category] || '\u{1F454}'}
@@ -314,7 +313,7 @@ export default function OutfitEditorPage() {
                       >
                         <div className="aspect-square rounded-[24px] overflow-hidden bg-white dark:bg-brand-800 border-2 border-brand-100 dark:border-brand-700 shadow-elevated group-hover/item:shadow-card-hover transition-all duration-500 group-hover/item:-translate-y-2">
                           {item.image_url ? (
-                            <img src={`${API_URL}${item.image_url}`} alt={item.category} className="w-full h-full object-cover" />
+                            <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />
                           ) : (
                             <div className="w-full h-full flex items-center justify-center text-4xl opacity-60">
                               {CAT_EMOJI[item.category] || '👔'}
@@ -662,7 +661,7 @@ export default function OutfitEditorPage() {
                       >
                         <div className="aspect-square rounded-[28px] overflow-hidden bg-white dark:bg-brand-800 border-2 border-brand-100 dark:border-brand-700 shadow-elevated group-hover/fs:shadow-card-hover group-hover/fs:-translate-y-2 transition-all duration-400">
                           {item.image_url ? (
-                            <img src={`${API_URL}${item.image_url}`} alt={item.category} className="w-full h-full object-cover" />
+                            <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />
                           ) : (
                             <div className="w-full h-full flex items-center justify-center text-5xl opacity-60">
                               {CAT_EMOJI[item.category] || '👔'}
@@ -733,7 +732,7 @@ function SwapSuggestions({ suggestions, onSwap }) {
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {suggestions.map((s, i) => {
           const delta = Math.round((s.score_delta ?? 0) * 100)
-          const imageUrl = s.add_item_image ? `${API_URL}${s.add_item_image}` : null
+          const imageUrl = s.add_item_image ? resolveUrl(s.add_item_image) : null
           return (
             <motion.button
               key={i}

--- a/frontend/src/pages/ProfileSettingsPage.jsx
+++ b/frontend/src/pages/ProfileSettingsPage.jsx
@@ -8,8 +8,7 @@ import { getConsent, updateConsent, getPrivacySummary, exportData, deleteAccount
 import { useAuth } from '../context/AuthContext.jsx'
 import PageWrapper from '../components/layout/PageWrapper.jsx'
 import LoadingSpinner from '../components/ui/LoadingSpinner.jsx'
-
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from '../utils/resolveUrl.js'
 
 const TABS = [
   { key: 'account',  label: 'Account' },
@@ -172,7 +171,7 @@ function AvatarTab({ profile, qc, updateUser }) {
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState('')
 
-  const currentAvatar = profile?.avatar_url ? `${API_URL}${profile.avatar_url}` : null
+  const currentAvatar = profile?.avatar_url ? resolveUrl(profile?.avatar_url) : null
   const displayName   = profile?.name || profile?.username || 'U'
 
   const mutation = useMutation({
@@ -281,7 +280,7 @@ function VtoTab() {
     queryFn: getPersonPhoto,
   })
 
-  const currentPhoto = vtoData?.photo_url ? `${API_URL}${vtoData.photo_url}` : null
+  const currentPhoto = vtoData?.photo_url ? resolveUrl(vtoData?.photo_url) : null
 
   const mutation = useMutation({
     mutationFn: () => {

--- a/frontend/src/utils/resolveUrl.js
+++ b/frontend/src/utils/resolveUrl.js
@@ -1,0 +1,7 @@
+const API_URL = import.meta.env.VITE_API_URL || ''
+
+export const resolveUrl = (url) => {
+  if (!url) return null
+  if (url.startsWith('http')) return url
+  return `${API_URL}${url}`
+}

--- a/frontend/src/utils/shareOutfit.js
+++ b/frontend/src/utils/shareOutfit.js
@@ -1,4 +1,4 @@
-const API_URL = import.meta.env.VITE_API_URL || ''
+import { resolveUrl } from './resolveUrl.js'
 
 function roundRect(ctx, x, y, w, h, r) {
   ctx.beginPath()
@@ -83,7 +83,7 @@ export async function generateOutfitImage(outfit, items) {
         await new Promise((resolve, reject) => {
           img.onload = resolve
           img.onerror = reject
-          img.src = `${API_URL}${imgUrl}`
+          img.src = resolveUrl(imgUrl)
         })
         ctx.save()
         roundRect(ctx, x, startY, imageSize, imageSize, 12)


### PR DESCRIPTION
## Summary
- Migrate all image storage from HF Storage Bucket to Supabase Storage (public `wardrobe-images` bucket)
- Fixes HF Space scheduling failures caused by bucket mount blocking container allocation
- Images now served via Supabase CDN — persistent across container restarts without needing HF bucket

## Changes
- **`app/storage.py`** (new) — Supabase Storage helper with upload/download/delete/URL functions
- **Backend (8 files)** — All routes upload to Supabase after processing, delete from Supabase on delete, download from Supabase when local file missing (ephemeral disk fallback)
- **Frontend (14 files)** — New `resolveUrl()` utility handles both absolute Supabase CDN URLs and relative `/uploads/` paths
- **`entrypoint.sh`** — Removed HF bucket symlink logic, kept temp workspace setup

## Env vars needed on HF Space
- `SUPABASE_URL` = `https://knvrrcltyaitsunlnqna.supabase.co`
- `SUPABASE_SERVICE_KEY` = (secret key from Supabase API settings)

## Test plan
- [x] 55 tests passing (auth + consent + wardrobe)
- [x] Frontend build succeeds (0 errors)
- [ ] Set SUPABASE_URL and SUPABASE_SERVICE_KEY on HF Space
- [ ] Upload wardrobe item → verify image in Supabase Storage bucket
- [ ] Verify images load on dashboard, wardrobe, social feed, outfit editor
- [ ] Restart Space → verify images persist (served from Supabase CDN)
- [ ] Delete item → verify removed from Supabase