### PR TITLE
fix: correct wardrobe insight pluralization for issue #73

### DIFF
--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -47,12 +47,18 @@ uploads_bp  = Blueprint("uploads",  __name__)
 VALID_FORMALITIES = {"casual", "formal", "both"}
 VALID_GENDERS     = {"men", "women", "unisex"}
 VALID_CATEGORIES  = {"top", "bottom", "outwear", "shoes", "dress", "jumpsuit"}
+IRREGULAR_PLURALS = {"shoes": "shoes", "dress": "dresses"}
 
 UPLOAD_TIPS = [
     "Lay the item flat or hang it for best results.",
     "Ensure good lighting — avoid shadows across the item.",
     "Crop to show only the clothing item, not the background.",
 ]
+
+
+def _pluralize_category(category: str) -> str:
+    """Pluralize wardrobe category names with small irregular overrides."""
+    return IRREGULAR_PLURALS.get(category, f"{category}s")
 
 
 # ─── POST /wardrobe/items ─────────────────────────────────────────────────────
@@ -411,7 +417,10 @@ def wardrobe_stats():
                 min_cat = min(min_essentials, key=min_essentials.get)
                 min_count = min_essentials[min_cat]
                 if max_count >= 3 * min_count and min_count > 0:
-                    balance_tip = f"You have {max_count} {max_cat}s but only {min_count} {min_cat}s. Consider adding more {min_cat}s for variety."
+                    balance_tip = (
+                        f"You have {max_count} {_pluralize_category(max_cat)} but only {min_count} {_pluralize_category(min_cat)}. "
+                        f"Consider adding more {_pluralize_category(min_cat)} for variety."
+                    )
 
     return jsonify({
         "wardrobe": {

--- a/tests/test_flask_stats_ootd.py
+++ b/tests/test_flask_stats_ootd.py
@@ -214,6 +214,37 @@ class TestWardrobeStats:
         assert tip is not None
         assert "bottom" in tip.lower() or "top" in tip.lower()
 
+    def test_stats_balance_tip_pluralizes_shoes(self, flask_app, client, auth_headers, minimal_png):
+        with flask_app.app_context():
+            for _ in range(6):
+                _upload_item(client, auth_headers, minimal_png, category="top")
+            for _ in range(3):
+                _upload_item(client, auth_headers, minimal_png, category="bottom")
+            for _ in range(2):
+                _upload_item(client, auth_headers, minimal_png, category="shoes")
+
+        resp = client.get("/wardrobe/stats", headers=auth_headers)
+        body = resp.get_json()
+        tip = (body["insights"].get("wardrobe_balance") or "").lower()
+
+        assert "shoes" in tip
+        assert "shoess" not in tip
+
+    def test_stats_balance_tip_pluralizes_dresses(self, flask_app, client, auth_headers, minimal_png):
+        with flask_app.app_context():
+            for _ in range(9):
+                _upload_item(client, auth_headers, minimal_png, category="dress")
+            _upload_item(client, auth_headers, minimal_png, category="top")
+            _upload_item(client, auth_headers, minimal_png, category="bottom")
+            _upload_item(client, auth_headers, minimal_png, category="shoes")
+
+        resp = client.get("/wardrobe/stats", headers=auth_headers)
+        body = resp.get_json()
+        tip = (body["insights"].get("wardrobe_balance") or "").lower()
+
+        assert "dresses" in tip
+        assert "dresss" not in tip
+
 
 # ─── OOTD ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Linked Issue
Fixes #73

## What Changed
- Replaced naive `cat + "s"` category pluralization in wardrobe balance insights with a dedicated backend pluralization helper.
- Added irregular handling for `shoes -> shoes` and `dress -> dresses` while preserving default pluralization for all other categories.
- Added regression tests covering both `shoess` and `dresss` failure modes in wardrobe stats insights.

## Files Changed
- app/wardrobe/routes.py: introduced `_pluralize_category()` and applied it to wardrobe balance tip generation.
- tests/test_flask_stats_ootd.py: added regression tests for `shoes` and `dresses` wording in insights.

## Test Evidence
- `py -3.11 -m pytest tests/test_flask_stats_ootd.py -k "pluralizes_shoes or pluralizes_dresses" -q` -> `6 passed in 97.73s`
- Pre-push gate (`scripts/preflight.sh` via git hook):
  - Core suite -> `128 passed in 256.72s`
  - Flake8 -> clean (`0`)
  - Migration check -> passed
  - Frontend build -> passed (`vite build ... built in 7.00s`)

## Manual QA Steps
1. Log in with a user that has many tops, fewer shoes, and enough essentials to trigger wardrobe imbalance insight; open Dashboard and verify insight text uses `shoes` (not `shoess`).
2. Log in with a user where dresses dominate inventory and imbalance insight triggers; verify insight text uses `dresses` (not `dresss`).
3. Verify other category words in insights still read naturally (for example `tops`, `bottoms`, `outwears`, `accessories` if applicable in your data).

## Risks and Rollback
- Risk level: low
- Rollback: revert commit `0fdd6de` to restore previous pluralization behavior.
