### PR TITLE
fix: occasion button text truncation on recommendations page (#74)

### DIFF
--- a/frontend/src/components/recommendations/OccasionPicker.jsx
+++ b/frontend/src/components/recommendations/OccasionPicker.jsx
@@ -18,7 +18,7 @@ export default function OccasionPicker({ value, onChange }) {
         </div>
       </div>
       
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-2 gap-4">
         {OCCASIONS.map(occ => (
           <motion.button
             key={occ.value}


### PR DESCRIPTION
## Linked Issue
Closes #74

## What Changed
`OccasionPicker.jsx` used `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`. With only 2 occasion buttons and the component living inside a narrow sidebar column (`lg:col-span-1`), the `lg:grid-cols-3` breakpoint compressed each button to ~100px — too narrow to render the full 6-character labels, causing "Casua..." and "Forma..." clipping.

Changed to `grid-cols-2` at all breakpoints (always correct since there are exactly 2 occasions).

## Files Changed
| File | Change |
|------|--------|
| `frontend/src/components/recommendations/OccasionPicker.jsx` | `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` → `grid-cols-2` |

## Test Evidence
- Preflight: **4/4 passed** (128 tests, flake8 clean, migrations clean, vite clean)
- No Python changes — no new backend tests needed (CSS-only fix)

## Manual QA Steps
1. Run the frontend dev server: `cd frontend && npm run dev`
2. Log in and go to the **Recommendations** page
3. **Primary check:** Both occasion buttons show full labels — **"Casual"** and **"Formal"** — no "Casua..." or "Forma..." clipping
4. Test at multiple viewport widths:
   - Wide desktop (≥1280px): 2 buttons side by side, full labels visible
   - Laptop (1024–1279px): same 2-column layout, labels intact
   - Tablet (768–1023px): 2 buttons side by side within the picker card, full labels visible
   - Mobile (<768px): 2 buttons side by side, no truncation
5. Click **Casual** → confirm dark selected state and active dot appear
6. Click **Formal** → confirm selected state switches correctly
7. Run a recommendations request end-to-end to confirm the rest of the flow is unaffected

## Risks and Rollback
- **Risk:** None — single CSS class change, no logic, no backend
- **Rollback:** Revert this one-line change if needed