### PR TITLE
fix: exclude formal-only items from casual occasion recommendations (#110)

### DIFF
--- a/engine/occasion_filter.py
+++ b/engine/occasion_filter.py
@@ -15,8 +15,8 @@ from engine.models import WardrobeItem, Occasion
 
 
 OCCASION_RULES: dict[str, set[str]] = {
-    "casual":  {"casual", "formal", "both"},   # All formalities allowed
-    "formal":  {"formal", "both"},             # No casual-only items
+    "casual":  {"casual", "both"},   # Formal-only items excluded from casual outfits
+    "formal":  {"formal", "both"},   # Casual-only items excluded from formal outfits
 }
 
 

--- a/tests/test_occasion_filter.py
+++ b/tests/test_occasion_filter.py
@@ -12,11 +12,24 @@ from tests.conftest import _make_item
 
 class TestOccasionFilter:
 
-    def test_casual_occasion_keeps_all_items(self, casual_item, formal_item, top_item):
+    def test_casual_occasion_excludes_formal_items(self, casual_item, formal_item, top_item):
+        """Casual occasion must not include strictly formal-only items."""
         from engine.occasion_filter import filter_by_occasion
         items = [casual_item, formal_item, top_item]
         result = filter_by_occasion(items, Occasion.CASUAL)
-        assert len(result) == 3  # casual allows everything
+        assert formal_item not in result
+        assert casual_item in result
+        assert top_item in result  # top_item is Formality.BOTH — stays in
+
+    def test_all_formal_items_casual_occasion_returns_empty(self):
+        """Wardrobe of purely formal items yields no casual candidates."""
+        from engine.occasion_filter import filter_by_occasion
+        items = [
+            _make_item(i, Category.TOP, formality=Formality.FORMAL)
+            for i in range(3)
+        ]
+        result = filter_by_occasion(items, Occasion.CASUAL)
+        assert result == []
 
     def test_formal_occasion_removes_casual_items(self, casual_item, formal_item):
         from engine.occasion_filter import filter_by_occasion


### PR DESCRIPTION
## Linked Issue
Closes #110

## What Changed
`OCCASION_RULES` for `"casual"` allowed `{"casual", "formal", "both"}` — meaning strictly formal items (dress shirts, formal trousers, Oxford shoes) could appear in casual outfit recommendations. This was asymmetric: formal correctly excluded casual items, but casual did not exclude formal items.

Changed `"casual"` rule to `{"casual", "both"}` — symmetric with the formal rule.

Items tagged `"both"` (versatile, user-set) remain included in both occasions as intended.

## Files Changed
| File | Change |
|------|--------|
| `engine/occasion_filter.py` | `"casual"` rule: `{"casual", "formal", "both"}` → `{"casual", "both"}` |
| `tests/test_occasion_filter.py` | Updated test to assert correct behaviour; added `test_all_formal_items_casual_occasion_returns_empty` |

## Test Evidence
- Preflight: **4/4 passed, 138 tests**
- All 7 occasion filter tests passed

## Manual QA Steps
1. Make sure your wardrobe has items tagged **Formal** (e.g. a dress shirt or formal trousers)
2. Go to **Recommendations → Casual**
3. Click **Get Outfits**
4. **Verify:** No formal-only items appear in any casual outfit result
5. Go to **Recommendations → Formal**
6. **Verify:** Formal items DO appear in formal outfits
7. **Verify:** Items tagged **"Both"** appear in both casual and formal results

## Risks and Rollback
- **Risk:** Users with small wardrobes tagged mostly as "Formal" may get fewer/no casual outfit results. This is correct behaviour — they need to retag some items as "Casual" or "Both".
- **Rollback:** Change `"casual"` back to `{"casual", "formal", "both"}` in `occasion_filter.py`.