### PR TITLE
fix: Today's Pick shows shoes placeholder when footwear missing

### DIFF
--- a/app/recommendations/routes.py
+++ b/app/recommendations/routes.py
@@ -460,6 +460,8 @@ def outfit_of_the_day():
             "is_fresh":         not bool(ids & recently_worn_ids),
         }
 
+    has_shoes = any(item.category == "shoes" for item in items_db)
+
     return _with_private_cache(jsonify({
         "outfit":   _fmt_outfit(top_outfits[0]),
         "outfits":  [_fmt_outfit(o) for o in top_outfits],
@@ -467,6 +469,7 @@ def outfit_of_the_day():
             "preferred_occasion":  occasion,
             "items_available":     len(items_db),
             "recently_worn_count": len(recently_worn_ids),
+            "has_shoes":           has_shoes,
         },
     })), 200
 

--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion, AnimatePresence } from 'framer-motion'
 import { toast } from 'sonner'
-import { FiSave, FiRefreshCw, FiSun, FiThermometer } from 'react-icons/fi'
+import { FiSave, FiRefreshCw, FiSun, FiThermometer, FiPlus } from 'react-icons/fi'
 import { getOOTD } from '../../api/recommendations.js'
 import { saveOutfit } from '../../api/outfits.js'
 import { scoreToPercent } from '../../utils/formatters.js'
@@ -84,6 +84,8 @@ export default function OOTDWidget() {
   }
 
   const pct = scoreToPercent(outfit.final_score)
+  const hasShoes = outfit.items?.some(i => i.category === 'shoes')
+  const hasShoesinWardrobe = data?.stats?.has_shoes
 
   return (
     <motion.div
@@ -153,6 +155,21 @@ export default function OOTDWidget() {
               <p className="text-[11px] text-brand-500 dark:text-brand-400 text-center mt-1.5 capitalize">{item.category}</p>
             </motion.div>
           ))}
+          {!hasShoes && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.85 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ delay: outfit.items.length * 0.08 }}
+              className="flex-shrink-0"
+            >
+              <div className="w-20 h-20 rounded-xl overflow-hidden bg-brand-100/40 dark:bg-brand-800/20 border-2 border-dashed border-brand-200/60 dark:border-brand-700/40 flex items-center justify-center">
+                <FiPlus className="text-brand-300 dark:text-brand-600" size={20} />
+              </div>
+              <p className="text-[10px] text-brand-400 dark:text-brand-500 text-center mt-1.5">
+                {hasShoesinWardrobe ? 'No match' : 'Add shoes'}
+              </p>
+            </motion.div>
+          )}
         </motion.div>
       </AnimatePresence>
 


### PR DESCRIPTION
Closes #76

## Summary
- **Backend**: Added `has_shoes` flag to OOTD stats response so the frontend knows if the user owns shoes
- **Frontend**: When Today's Pick outfit has no shoes, shows a dashed placeholder slot with context-aware label:
  - "Add shoes" — when the user has no shoes in their wardrobe
  - "No match" — when shoes exist but didn't fit the outfit scoring

Note: The engine already prefers complete outfits via the completeness bonus (commit a4bdd8b). This PR adds the visual indicator for the remaining cases where a 2-item outfit still wins.

## Test plan
- [ ] Upload a wardrobe with tops + bottoms + shoes → Today's Pick should show 3 items (no placeholder)
- [ ] Upload a wardrobe with tops + bottoms only (no shoes) → Today's Pick shows 2 items + dashed "Add shoes" placeholder
- [ ] Click "Different" to cycle outfits — placeholder should appear/disappear correctly
- [ ] Verify placeholder styling matches the card design (dashed border, muted colors)