### PR TITLE
fix: Today's Pick outfit items wrap on mobile — no more clipping at 390px

### DIFF
--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -131,7 +131,7 @@ export default function OOTDWidget() {
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           exit={{ opacity: 0, x: -20 }}
-          className="flex gap-3 mb-5 overflow-x-auto pb-1"
+          className="flex flex-wrap gap-3 mb-5"
         >
           {outfit.items.map((item, idx) => (
             <motion.div


### PR DESCRIPTION
Closes #79

## Summary
Single class change: `overflow-x-auto` horizontal scroll → `flex-wrap` so outfit items flow to a second row on narrow viewports instead of being cut off.

## Test plan
- [ ] Chrome DevTools → 375px (iPhone SE): all items visible, wrap to second row if needed
- [ ] Chrome DevTools → 390px (iPhone 14): same
- [ ] Chrome DevTools → 414px (iPhone Pro Max): same
- [ ] Chrome DevTools → 768px (tablet): items still in a single row
- [ ] Chrome DevTools → 1280px (desktop): unchanged