### PR TITLE
feat: add dedicated 404 page — replace silent catch-all redirect

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import ProfileSettingsPage from './pages/ProfileSettingsPage.jsx'
 import OnboardingFlow from './components/onboarding/OnboardingFlow.jsx'
 import ForgotPasswordPage from './pages/ForgotPasswordPage.jsx'
 import ResetPasswordPage from './pages/ResetPasswordPage.jsx'
+import NotFoundPage from './pages/NotFoundPage.jsx'
 
 function Layout({ children }) {
   return (
@@ -118,7 +119,7 @@ export default function App() {
       <Route path="/" element={
         <Navigate to={isAuthenticated ? '/dashboard' : '/login'} replace />
       } />
-      <Route path="*" element={<Navigate to="/" replace />} />
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   )
 }

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { FiArrowRight } from 'react-icons/fi'
+
+export default function NotFoundPage() {
+  useEffect(() => {
+    const prev = document.title
+    document.title = '404 — Page Not Found | OutfitAI'
+    return () => { document.title = prev }
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-brand-50 dark:bg-brand-950 flex items-center justify-center px-4">
+      <motion.div
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+        className="text-center max-w-sm"
+      >
+        <p className="font-mono text-7xl font-bold text-accent-500 mb-4 select-none">404</p>
+        <h1 className="font-display text-2xl font-semibold text-brand-800 dark:text-brand-200 mb-2">
+          Page not found
+        </h1>
+        <p className="text-sm text-brand-400 dark:text-brand-500 mb-8">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <Link
+          to="/dashboard"
+          className="inline-flex items-center gap-2 btn-accent px-5 py-2.5 rounded-xl text-sm font-medium"
+        >
+          Go to Dashboard
+          <FiArrowRight size={14} />
+        </Link>
+      </motion.div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #75

## Summary
- Created `frontend/src/pages/NotFoundPage.jsx` — branded 404 page with gold accent, dark mode support, and "Go to Dashboard" CTA
- Sets browser tab title to `404 — Page Not Found | OutfitAI`
- Updated `App.jsx` catch-all route from `<Navigate to="/" replace />` to `<NotFoundPage />`

## Test plan
- [ ] Navigate to `/this-does-not-exist` → 404 page renders (not a redirect)
- [ ] Browser tab title shows "404 — Page Not Found | OutfitAI"
- [ ] "Go to Dashboard →" button navigates to `/dashboard`
- [ ] Browser back button works from the 404 page
- [ ] Dark mode: page matches app design system