### PR TITLE
feat: add score info tooltip to outfit match percentage

### DIFF
--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -7,6 +7,7 @@ import { getOOTD } from '../../api/recommendations.js'
 import { saveOutfit } from '../../api/outfits.js'
 import { scoreToPercent } from '../../utils/formatters.js'
 import ConfidenceBadge from '../ui/ConfidenceBadge.jsx'
+import ScoreInfoTooltip from '../ui/ScoreInfoTooltip.jsx'
 import RetryImage from '../ui/RetryImage.jsx'
 import { resolveUrl } from '../../utils/resolveUrl.js'
 
@@ -118,6 +119,7 @@ export default function OOTDWidget() {
         </div>
         <div className="text-right">
           <span className="data-value text-2xl">{pct}%</span>
+          <ScoreInfoTooltip />
           <div className="mt-1">
             <ConfidenceBadge level={outfit.confidence} />
           </div>

--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -119,7 +119,7 @@ export default function OOTDWidget() {
         </div>
         <div className="text-right">
           <span className="data-value text-2xl">{pct}%</span>
-          <ScoreInfoTooltip />
+          <ScoreInfoTooltip placement="down" />
           <div className="mt-1">
             <ConfidenceBadge level={outfit.confidence} />
           </div>

--- a/frontend/src/components/recommendations/OutfitCard.jsx
+++ b/frontend/src/components/recommendations/OutfitCard.jsx
@@ -7,6 +7,7 @@ import OutfitItems from './OutfitItems.jsx'
 import WhyThisOutfit from './WhyThisOutfit.jsx'
 import FeedbackButtons from './FeedbackButtons.jsx'
 import ConfidenceBadge from '../ui/ConfidenceBadge.jsx'
+import ScoreInfoTooltip from '../ui/ScoreInfoTooltip.jsx'
 import { scoreToPercent } from '../../utils/formatters.js'
 import ShareButton from '../ui/ShareButton.jsx'
 import OutfitTryOnModal from '../tryon/OutfitTryOnModal.jsx'
@@ -88,6 +89,7 @@ export default function OutfitCard({ outfit, occasion }) {
             </div>
             <div className="flex items-baseline gap-2">
               <span className="data-value text-4xl leading-none">{pct}%</span>
+              <ScoreInfoTooltip />
               <span className={`font-display text-lg font-medium italic ${pct >= 75 ? 'text-emerald-500' : pct >= 55 ? 'text-emerald-500/70' : pct >= 40 ? 'text-amber-500' : 'text-red-400'}`}>
                 {pct >= 75 ? 'Great Match' : pct >= 55 ? 'Good Match' : pct >= 40 ? 'Fair Match' : 'Weak Match'}
               </span>

--- a/frontend/src/components/ui/ScoreInfoTooltip.jsx
+++ b/frontend/src/components/ui/ScoreInfoTooltip.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { FiInfo } from 'react-icons/fi'
+
+/**
+ * Small ⓘ icon that shows a tooltip explaining the outfit match score.
+ * Works on desktop (hover) and mobile (tap to toggle).
+ */
+export default function ScoreInfoTooltip() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <span className="relative inline-flex items-center">
+      <button
+        type="button"
+        aria-label="What does this score mean?"
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+        onBlur={() => setOpen(false)}
+        className="group flex items-center justify-center w-5 h-5 rounded-full text-brand-300 hover:text-accent-500 dark:text-brand-600 dark:hover:text-accent-400 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+      >
+        <FiInfo size={13} />
+      </button>
+
+      {open && (
+        <div
+          role="tooltip"
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-60 z-50 bg-brand-900 dark:bg-brand-100 text-white dark:text-brand-900 text-[11px] rounded-xl shadow-xl px-3.5 py-3 pointer-events-none"
+        >
+          <p className="font-semibold mb-1.5">Match Score</p>
+          <p className="text-brand-300 dark:text-brand-600 mb-2">Combines 4 factors:</p>
+          <ul className="space-y-0.5 text-brand-200 dark:text-brand-700">
+            <li><span className="font-medium text-white dark:text-brand-900">Style</span> — how well pieces pair together</li>
+            <li><span className="font-medium text-white dark:text-brand-900">Color</span> — color harmony between items</li>
+            <li><span className="font-medium text-white dark:text-brand-900">Weather</span> — suitability for today&apos;s temperature</li>
+            <li><span className="font-medium text-white dark:text-brand-900">Cohesion</span> — formality &amp; occasion consistency</li>
+          </ul>
+          <div className="mt-2 pt-2 border-t border-brand-700 dark:border-brand-300 text-brand-400 dark:text-brand-500">
+            85%+ great · 70–84% good · &lt;70% fair
+          </div>
+          {/* Arrow */}
+          <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-brand-900 dark:border-t-brand-100" />
+        </div>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/ui/ScoreInfoTooltip.jsx
+++ b/frontend/src/components/ui/ScoreInfoTooltip.jsx
@@ -5,8 +5,20 @@ import { FiInfo } from 'react-icons/fi'
  * Small ⓘ icon that shows a tooltip explaining the outfit match score.
  * Works on desktop (hover) and mobile (tap to toggle).
  */
-export default function ScoreInfoTooltip() {
+/**
+ * placement: "up" (default) — tooltip appears above the icon
+ *            "down"         — tooltip appears below (use when card is near top of viewport)
+ */
+export default function ScoreInfoTooltip({ placement = 'up' }) {
   const [open, setOpen] = useState(false)
+
+  const above = placement === 'up'
+  const tooltipPos = above
+    ? 'bottom-full left-1/2 -translate-x-1/2 mb-2'
+    : 'top-full right-0 mt-2'
+  const arrowClass = above
+    ? 'absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-brand-900 dark:border-t-brand-100'
+    : 'absolute bottom-full right-4 border-4 border-transparent border-b-brand-900 dark:border-b-brand-100'
 
   return (
     <span className="relative inline-flex items-center">
@@ -24,7 +36,7 @@ export default function ScoreInfoTooltip() {
       {open && (
         <div
           role="tooltip"
-          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-60 z-50 bg-brand-900 dark:bg-brand-100 text-white dark:text-brand-900 text-[11px] rounded-xl shadow-xl px-3.5 py-3 pointer-events-none"
+          className={`absolute ${tooltipPos} w-60 z-50 bg-brand-900 dark:bg-brand-100 text-white dark:text-brand-900 text-[11px] rounded-xl shadow-xl px-3.5 py-3 pointer-events-none`}
         >
           <p className="font-semibold mb-1.5">Match Score</p>
           <p className="text-brand-300 dark:text-brand-600 mb-2">Combines 4 factors:</p>
@@ -37,8 +49,7 @@ export default function ScoreInfoTooltip() {
           <div className="mt-2 pt-2 border-t border-brand-700 dark:border-brand-300 text-brand-400 dark:text-brand-500">
             85%+ great · 70–84% good · &lt;70% fair
           </div>
-          {/* Arrow */}
-          <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-brand-900 dark:border-t-brand-100" />
+          <div className={arrowClass} />
         </div>
       )}
     </span>


### PR DESCRIPTION
Closes #82

## Summary
- Created `ScoreInfoTooltip.jsx` — a small ⓘ icon that shows a tooltip explaining the 4 scoring factors (Style, Color, Weather, Cohesion) and score thresholds
- Works on desktop (hover/click) and mobile (tap to toggle, tap away to close)
- Keyboard accessible (focus-visible ring, aria-label, aria-expanded)
- Added to `OutfitCard.jsx` (next to the `{pct}%` value) and `OOTDWidget.jsx`

## Test plan
- [ ] Recommendations page: click ⓘ next to score — tooltip appears explaining 4 factors
- [ ] Dashboard Today's Pick: click ⓘ — same tooltip
- [ ] Mobile: tap ⓘ opens tooltip, tap elsewhere closes it
- [ ] Keyboard: Tab to ⓘ, Enter to open, blur to close
- [ ] Dark mode: tooltip uses correct inverted colors