### PR TITLE
feat: add onError fallback placeholders to all wardrobe item images

### DIFF
--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -143,16 +143,15 @@ export default function OOTDWidget() {
               transition={{ delay: idx * 0.08 }}
               className="flex-shrink-0"
             >
-              <div className="w-20 h-20 rounded-xl overflow-hidden bg-brand-100/60 dark:bg-brand-800/40 border border-brand-100/60 dark:border-brand-700/40 shadow-sm">
-                {item.image_url && (
-                  <RetryImage
-                    src={resolveUrl(item.image_url)}
-                    alt={item.category}
-                    loading="lazy"
-                    decoding="async"
-                    className="w-full h-full object-cover"
-                  />
-                )}
+              <div className="w-20 h-20 rounded-xl overflow-hidden bg-brand-100/60 dark:bg-brand-800/40 border border-brand-100/60 dark:border-brand-700/40 shadow-sm flex items-center justify-center">
+                <RetryImage
+                  src={resolveUrl(item.image_url)}
+                  alt={item.category}
+                  loading="lazy"
+                  decoding="async"
+                  className="w-full h-full object-cover"
+                  fallback={<span className="text-3xl opacity-50">👔</span>}
+                />
               </div>
               <p className="text-[11px] text-brand-500 dark:text-brand-400 text-center mt-1.5 capitalize">{item.category}</p>
             </motion.div>

--- a/frontend/src/components/recommendations/OutfitItems.jsx
+++ b/frontend/src/components/recommendations/OutfitItems.jsx
@@ -24,19 +24,18 @@ export default function OutfitItems({ items }) {
               {/* Subtle overlay gradient */}
               <div className="absolute inset-0 bg-gradient-to-t from-brand-900/10 to-transparent opacity-0 group-hover/item:opacity-100 transition-opacity" />
               
-              {imageUrl ? (
-                <RetryImage
-                  src={imageUrl}
-                  alt={item.category}
-                  loading="lazy"
-                  decoding="async"
-                  className="w-full h-full object-cover"
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-3xl opacity-40 grayscale">
-                  {CAT_EMOJI[item.category] || '\u{1F454}'}
-                </div>
-              )}
+              <RetryImage
+                src={imageUrl}
+                alt={item.category}
+                loading="lazy"
+                decoding="async"
+                className="w-full h-full object-cover"
+                fallback={
+                  <div className="w-full h-full flex items-center justify-center text-3xl opacity-40 grayscale">
+                    {CAT_EMOJI[item.category] || '\u{1F454}'}
+                  </div>
+                }
+              />
             </div>
             
             <div className="mt-2 flex flex-col items-center">

--- a/frontend/src/components/wardrobe/WardrobeCard.jsx
+++ b/frontend/src/components/wardrobe/WardrobeCard.jsx
@@ -51,19 +51,18 @@ export default function WardrobeCard({ item, onDelete }) {
       >
         {/* Image */}
         <div className="relative aspect-square bg-brand-100/60 dark:bg-brand-800/40 overflow-hidden">
-          {imageUrl ? (
-            <RetryImage
-              src={imageUrl}
-              alt={`${item.category} item`}
-              loading="lazy"
-              decoding="async"
-              className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-            />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center text-5xl opacity-60">
-              {CAT_EMOJI[item.category] || '👔'}
-            </div>
-          )}
+          <RetryImage
+            src={imageUrl}
+            alt={`${item.category} item`}
+            loading="lazy"
+            decoding="async"
+            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+            fallback={
+              <div className="w-full h-full flex items-center justify-center text-5xl opacity-60">
+                {CAT_EMOJI[item.category] || '👔'}
+              </div>
+            }
+          />
 
           {/* Overlay gradient */}
           <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -75,19 +75,18 @@ export default function DashboardPage() {
                   key={i}
                   className="w-10 h-10 rounded-full overflow-hidden border-2 border-white dark:border-brand-900 bg-brand-100 dark:bg-brand-800"
                 >
-                  {item.image_url ? (
-                    <RetryImage
-                      src={resolveUrl(item.image_url)}
-                      alt={item.category}
-                      loading="lazy"
-                      decoding="async"
-                      className="w-full h-full object-cover"
-                    />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center text-lg opacity-30">
-                      {todayPlan.occasion === 'formal' ? '👔' : '👕'}
-                    </div>
-                  )}
+                  <RetryImage
+                    src={resolveUrl(item.image_url)}
+                    alt={item.category}
+                    loading="lazy"
+                    decoding="async"
+                    className="w-full h-full object-cover"
+                    fallback={
+                      <div className="w-full h-full flex items-center justify-center text-lg opacity-30">
+                        {todayPlan.occasion === 'formal' ? '👔' : '👕'}
+                      </div>
+                    }
+                  />
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/RecommendationsPage.jsx
+++ b/frontend/src/pages/RecommendationsPage.jsx
@@ -125,16 +125,15 @@ export default function RecommendationsPage() {
       {/* Anchor item banner */}
       {anchorItem && (
         <div className="card p-4 mb-6 flex items-center gap-4 border-accent-300/40 dark:border-accent-700/40 bg-accent-50/50 dark:bg-accent-900/10">
-          <div className="w-14 h-14 rounded-xl overflow-hidden bg-white dark:bg-brand-800 border border-accent-200/60 dark:border-accent-700/40">
-            {anchorItem.image_url && (
-              <RetryImage
-                src={resolveUrl(anchorItem.image_url)}
-                alt={anchorItem.category}
-                loading="lazy"
-                decoding="async"
-                className="w-full h-full object-cover"
-              />
-            )}
+          <div className="w-14 h-14 rounded-xl overflow-hidden bg-white dark:bg-brand-800 border border-accent-200/60 dark:border-accent-700/40 flex items-center justify-center">
+            <RetryImage
+              src={resolveUrl(anchorItem.image_url)}
+              alt={anchorItem.category}
+              loading="lazy"
+              decoding="async"
+              className="w-full h-full object-cover"
+              fallback={<span className="text-2xl opacity-50">👔</span>}
+            />
           </div>
           <div>
             <p className="text-sm font-semibold text-accent-700 dark:text-accent-400">Building outfit around:</p>


### PR DESCRIPTION
Closes #89

## Summary
`RetryImage` already had a `fallback` prop but no caller passed it — so failed images rendered as blank space. This PR passes category emoji fallbacks to all 5 `RetryImage` usages:

- `WardrobeCard.jsx` — category-specific emoji (👕👖🧥👟👗🧘)
- `OutfitItems.jsx` — same emoji set
- `OOTDWidget.jsx` — generic 👔
- `DashboardPage.jsx` — occasion-aware (👔 formal / 👕 casual)
- `RecommendationsPage.jsx` — generic 👔

## Test plan
- [ ] Temporarily break an image URL in DevTools → emoji placeholder appears instead of blank
- [ ] Wardrobe page: broken image shows category emoji
- [ ] Recommendations page: anchor item banner shows emoji on broken image
- [ ] Today's Pick: item slot shows emoji fallback on failure