### PR TITLE
feat: reframe dashboard insights copy — positive capability framing

### DIFF
--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -406,11 +406,11 @@ def wardrobe_stats():
         has_shoes = categories.get("shoes", 0)
 
         if has_tops > 0 and has_bottoms == 0:
-            balance_tip = "You have tops but no bottoms. Add some pants or skirts for complete outfits."
+            balance_tip = "Your tops are ready — adding some pants or skirts will unlock complete outfit recommendations."
         elif has_bottoms > 0 and has_tops == 0:
-            balance_tip = "You have bottoms but no tops. Add some shirts or t-shirts for complete outfits."
+            balance_tip = "Your bottoms are ready — adding some shirts or t-shirts will unlock complete outfit recommendations."
         elif has_shoes == 0 and total_items >= 3:
-            balance_tip = "You don't have any shoes yet. Add footwear to get full outfit recommendations."
+            balance_tip = "Great start! Adding footwear will unlock full 3-piece outfit recommendations."
         else:
             # Check for big imbalances
             max_cat = max(categories, key=categories.get)
@@ -421,8 +421,8 @@ def wardrobe_stats():
                 min_count = min_essentials[min_cat]
                 if max_count >= 3 * min_count and min_count > 0:
                     balance_tip = (
-                        f"You have {max_count} {_pluralize_category(max_cat)} but only {min_count} {_pluralize_category(min_cat)}. "
-                        f"Consider adding more {_pluralize_category(min_cat)} for variety."
+                        f"Your {_pluralize_category(max_cat)} are well-stocked! "
+                        f"Adding more {_pluralize_category(min_cat)} could unlock more complete outfit looks."
                     )
 
     response = jsonify({

--- a/frontend/src/components/dashboard/WardrobeStats.jsx
+++ b/frontend/src/components/dashboard/WardrobeStats.jsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
-import { FiBarChart2, FiAlertTriangle, FiInfo, FiTrendingUp } from 'react-icons/fi'
+import { FiBarChart2, FiZap, FiInfo, FiTrendingUp, FiArrowRight } from 'react-icons/fi'
 import { getWardrobeStats } from '../../api/wardrobe.js'
 import { pluralizeCategory } from '../../utils/formatters.js'
 
@@ -93,22 +93,12 @@ export default function WardrobeStats() {
         <h2 className="font-display text-2xl font-semibold text-brand-800 dark:text-brand-200">Insights</h2>
       </div>
 
-      {/* Capacity */}
+      {/* Item count — capability framing */}
       <div className="mb-6">
-        <div className="flex justify-between text-xs text-brand-500 dark:text-brand-400 mb-1.5">
-          <span>{wardrobe.total_items ?? 0} / {wardrobe.capacity ?? 50} items</span>
-          <span className="font-mono font-semibold">{capacityPct}%</span>
-        </div>
-        <div className="h-1.5 bg-brand-100/60 dark:bg-brand-800/40 rounded-full overflow-hidden">
-          <motion.div
-            initial={{ width: 0 }}
-            animate={{ width: `${capacityPct}%` }}
-            transition={{ duration: 1, ease: [0.16, 1, 0.3, 1] }}
-            className={`h-full rounded-full ${
-              capacityPct >= 90 ? 'bg-red-500' : capacityPct >= 70 ? 'bg-amber-500' : 'bg-accent-500'
-            }`}
-          />
-        </div>
+        <p className="text-xs text-brand-500 dark:text-brand-400 mb-1">
+          <span className="font-semibold text-brand-700 dark:text-brand-300">{wardrobe.total_items ?? 0} items</span>
+          {(wardrobe.total_items ?? 0) > 0 ? ' — ready for recommendations' : ' — upload your first item to get started'}
+        </p>
       </div>
 
       {/* Categories */}
@@ -160,18 +150,26 @@ export default function WardrobeStats() {
 
       {/* Insights */}
       {insights.wardrobe_balance && (
-        <div className="flex items-start gap-2.5 p-3 bg-amber-50/60 dark:bg-amber-900/10 border border-amber-200/40 dark:border-amber-800/30 rounded-xl text-sm text-amber-700 dark:text-amber-300">
-          <FiAlertTriangle size={14} className="mt-0.5 flex-shrink-0" />
+        <div className="flex items-start gap-2.5 p-3 bg-accent-50/60 dark:bg-accent-900/10 border border-accent-200/40 dark:border-accent-800/30 rounded-xl text-sm text-accent-700 dark:text-accent-300">
+          <FiZap size={14} className="mt-0.5 flex-shrink-0" />
           <span>{insights.wardrobe_balance}</span>
         </div>
       )}
 
       {(insights.never_used_item_ids?.length ?? 0) > 0 && (
-        <div className="flex items-start gap-2.5 p-3 mt-2 bg-sky-50/60 dark:bg-sky-900/10 border border-sky-200/40 dark:border-sky-800/30 rounded-xl text-sm text-sky-700 dark:text-sky-300">
-          <FiInfo size={14} className="mt-0.5 flex-shrink-0" />
-          <span>
-            {insights.never_used_item_ids.length} item{insights.never_used_item_ids.length !== 1 ? 's' : ''} never used in any recommendation.
-          </span>
+        <div className="p-3 mt-2 bg-sky-50/60 dark:bg-sky-900/10 border border-sky-200/40 dark:border-sky-800/30 rounded-xl">
+          <div className="flex items-start gap-2.5 text-sm text-sky-700 dark:text-sky-300 mb-2">
+            <FiInfo size={14} className="mt-0.5 flex-shrink-0" />
+            <span>
+              {insights.never_used_item_ids.length} item{insights.never_used_item_ids.length !== 1 ? 's' : ''} waiting to shine — try a new occasion to unlock them.
+            </span>
+          </div>
+          <a
+            href="/recommendations"
+            className="flex items-center gap-1 text-[11px] font-medium text-sky-600 dark:text-sky-400 hover:underline ml-6"
+          >
+            Explore recommendations <FiArrowRight size={11} />
+          </a>
         </div>
       )}
 


### PR DESCRIPTION
Closes #102

## Changes

**Backend (`app/wardrobe/routes.py`):**
- "You have tops but no bottoms..." → "Your tops are ready — adding pants/skirts will unlock..."
- "You don't have any shoes yet..." → "Great start! Adding footwear will unlock full 3-piece..."
- "You have X tops but only Y shoes. Consider adding..." → "Your tops are well-stocked! Adding more shoes could unlock..."

**Frontend (`WardrobeStats.jsx`):**
- Capacity bar (`19 / 50 items — 38%`) → capability statement (`19 items — ready for recommendations`)
- Warning icon (⚠) → Zap icon (⚡) for balance tips
- "13 items never used in any recommendation" → "13 items waiting to shine — try a new occasion to unlock them" + "Explore recommendations →" CTA

## Test plan
- [ ] Dashboard Insights: no "never used" or "consider adding" language visible
- [ ] Balance tip shows positive framing when category imbalance exists
- [ ] "Explore recommendations →" link navigates to `/recommendations`
- [ ] Item count shows "X items — ready for recommendations" (no progress bar)