### PR TITLE
feat: replace raw % scores with qualitative match labels (#104)

### DIFF
--- a/frontend/src/components/dashboard/WardrobeStats.jsx
+++ b/frontend/src/components/dashboard/WardrobeStats.jsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import { FiBarChart2, FiZap, FiInfo, FiTrendingUp, FiArrowRight } from 'react-icons/fi'
 import { getWardrobeStats } from '../../api/wardrobe.js'
-import { pluralizeCategory } from '../../utils/formatters.js'
+import { pluralizeCategory, scoreToLabel } from '../../utils/formatters.js'
 
 const CAT_COLORS = {
   top: 'bg-sky-500',
@@ -133,7 +133,7 @@ export default function WardrobeStats() {
         {activity.avg_score != null && (
           <div className="bg-brand-50/60 dark:bg-brand-800/30 rounded-xl p-3 text-center border border-brand-100/40 dark:border-brand-800/30">
             <div className="text-xl font-mono font-bold text-brand-900 dark:text-brand-100">{Math.round(activity.avg_score * 100)}%</div>
-            <div className="text-[10px] text-brand-500 dark:text-brand-400 mt-0.5">Avg Score</div>
+            <div className="text-[10px] font-medium text-accent-600 dark:text-accent-400 mt-0.5">{scoreToLabel(activity.avg_score)}</div>
           </div>
         )}
         {(feedback.thumbs_up > 0 || feedback.thumbs_down > 0) && (

--- a/frontend/src/components/recommendations/OutfitCard.jsx
+++ b/frontend/src/components/recommendations/OutfitCard.jsx
@@ -8,7 +8,7 @@ import WhyThisOutfit from './WhyThisOutfit.jsx'
 import FeedbackButtons from './FeedbackButtons.jsx'
 import ConfidenceBadge from '../ui/ConfidenceBadge.jsx'
 import ScoreInfoTooltip from '../ui/ScoreInfoTooltip.jsx'
-import { scoreToPercent } from '../../utils/formatters.js'
+import { scoreToPercent, scoreToLabel } from '../../utils/formatters.js'
 import ShareButton from '../ui/ShareButton.jsx'
 import OutfitTryOnModal from '../tryon/OutfitTryOnModal.jsx'
 
@@ -90,8 +90,8 @@ export default function OutfitCard({ outfit, occasion }) {
             <div className="flex items-baseline gap-2">
               <span className="data-value text-4xl leading-none">{pct}%</span>
               <ScoreInfoTooltip />
-              <span className={`font-display text-lg font-medium italic ${pct >= 75 ? 'text-emerald-500' : pct >= 55 ? 'text-emerald-500/70' : pct >= 40 ? 'text-amber-500' : 'text-red-400'}`}>
-                {pct >= 75 ? 'Great Match' : pct >= 55 ? 'Good Match' : pct >= 40 ? 'Fair Match' : 'Weak Match'}
+              <span className={`font-display text-lg font-medium italic ${pct >= 80 ? 'text-emerald-500' : pct >= 70 ? 'text-emerald-500/70' : pct >= 60 ? 'text-amber-500' : 'text-red-400'}`}>
+                {scoreToLabel(outfit.final_score)}
               </span>
             </div>
           </div>

--- a/frontend/src/components/recommendations/OutfitCard.jsx
+++ b/frontend/src/components/recommendations/OutfitCard.jsx
@@ -89,7 +89,7 @@ export default function OutfitCard({ outfit, occasion }) {
             </div>
             <div className="flex items-baseline gap-2">
               <span className="data-value text-4xl leading-none">{pct}%</span>
-              <ScoreInfoTooltip />
+              <ScoreInfoTooltip placement="down" />
               <span className={`font-display text-lg font-medium italic ${pct >= 80 ? 'text-emerald-500' : pct >= 70 ? 'text-emerald-500/70' : pct >= 60 ? 'text-amber-500' : 'text-red-400'}`}>
                 {scoreToLabel(outfit.final_score)}
               </span>

--- a/frontend/src/components/ui/ScoreInfoTooltip.jsx
+++ b/frontend/src/components/ui/ScoreInfoTooltip.jsx
@@ -15,10 +15,10 @@ export default function ScoreInfoTooltip({ placement = 'up' }) {
   const above = placement === 'up'
   const tooltipPos = above
     ? 'bottom-full left-1/2 -translate-x-1/2 mb-2'
-    : 'top-full right-0 mt-2'
+    : 'top-full left-0 mt-2'
   const arrowClass = above
     ? 'absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-brand-900 dark:border-t-brand-100'
-    : 'absolute bottom-full right-4 border-4 border-transparent border-b-brand-900 dark:border-b-brand-100'
+    : 'absolute bottom-full left-4 border-4 border-transparent border-b-brand-900 dark:border-b-brand-100'
 
   return (
     <span className="relative inline-flex items-center">

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -48,6 +48,16 @@ export function scoreToPercent(score) {
   return Math.round((score ?? 0) * 100)
 }
 
+// Qualitative match label scale (score is 0–1)
+export function scoreToLabel(score) {
+  const pct = scoreToPercent(score)
+  if (pct >= 90) return 'Perfect Match'
+  if (pct >= 80) return 'Strong Match'
+  if (pct >= 70) return 'Good Match'
+  if (pct >= 60) return 'Fair Match'
+  return 'Weak Match'
+}
+
 export function confidenceColor(level) {
   switch (level?.toLowerCase()) {
     case 'high':   return 'confidence-high'


### PR DESCRIPTION
## Summary
- Adds `scoreToLabel()` to `formatters.js` — maps score to Perfect/Strong/Good/Fair/Weak Match
- **OutfitCard**: qualitative label now appears beside the percentage (e.g. `72%` → `Good Match` in italic)
- **WardrobeStats**: avg score tile now shows the qualitative label below the number in accent color

## Changes
| File | Change |
|------|--------|
| `frontend/src/utils/formatters.js` | Added `scoreToLabel(score)` function |
| `frontend/src/components/recommendations/OutfitCard.jsx` | Use `scoreToLabel` for label display |
| `frontend/src/components/dashboard/WardrobeStats.jsx` | Show qualitative label under avg score % |

## Test steps
1. Get recommendations — outfit card shows e.g. **"72% Good Match"** (italic, color-coded)
2. Dashboard → Insights panel → avg score tile shows **"Strong Match"** (or applicable label) below the percentage
3. Labels map: ≥90% Perfect, ≥80% Strong, ≥70% Good, ≥60% Fair, below Weak

Closes #104