### PR TITLE
feat: engagement metrics on social feed cards (#115)

### DIFF
--- a/frontend/src/components/social/FeedCard.jsx
+++ b/frontend/src/components/social/FeedCard.jsx
@@ -8,6 +8,9 @@ import VibeTagPill from './VibeTagPill.jsx'
 import ConfirmDialog from '../ui/ConfirmDialog.jsx'
 import { useAuth } from '../../context/AuthContext.jsx'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { formatRelativeTime } from '../../utils/formatters.js'
+
+const TRENDING_LIKES_THRESHOLD = 20
 
 export default function FeedCard({ post, onRemixClick, onVibeClick, onPostClick }) {
   const { user } = useAuth()
@@ -61,7 +64,8 @@ export default function FeedCard({ post, onRemixClick, onVibeClick, onPostClick 
   const previewUrl  = post.preview_url ? resolveUrl(post.preview_url) : null
   const itemImages  = post.outfit?.item_images ?? []
   const username    = post.user?.username || `user_${post.user_id}`
-  const timeAgo     = _timeAgo(post.created_at)
+  const timeAgo     = formatRelativeTime(post.created_at)
+  const isTrending  = likeCount >= TRENDING_LIKES_THRESHOLD
 
   return (
     <>
@@ -95,9 +99,16 @@ export default function FeedCard({ post, onRemixClick, onVibeClick, onPostClick 
             <OccasionCard outfit={post.outfit} />
           )}
 
+          {/* Trending badge */}
+          {isTrending && (
+            <div className="absolute top-2 left-2 bg-black/60 text-white text-[10px] font-semibold px-2 py-0.5 rounded-full backdrop-blur-sm flex items-center gap-1">
+              🔥 Trending
+            </div>
+          )}
+
           {/* Remix source badge */}
           {post.remix_source_post_id && (
-            <div className="absolute top-2 left-2 bg-black/50 text-white text-[10px] px-2 py-0.5 rounded-full backdrop-blur-sm">
+            <div className={`absolute text-white text-[10px] px-2 py-0.5 rounded-full backdrop-blur-sm bg-black/50 ${isTrending ? 'top-2 left-[90px]' : 'top-2 left-2'}`}>
               Remixed
             </div>
           )}
@@ -193,7 +204,7 @@ export default function FeedCard({ post, onRemixClick, onVibeClick, onPostClick 
                 className="flex items-center gap-1 px-2 py-1.5 rounded-lg text-xs font-medium text-brand-500 hover:text-accent-600 hover:bg-accent-50 dark:hover:bg-accent-900/15 transition-all"
               >
                 <FiRefreshCw size={13} />
-                <span>{post.remix_count > 0 ? post.remix_count : 'Remix'}</span>
+                <span>{post.remix_count ?? 0}</span>
               </button>
             )}
 
@@ -311,14 +322,3 @@ function OccasionCard({ outfit }) {
   )
 }
 
-/* ─── Helpers ───────────────────────────────────────────────────────── */
-
-function _timeAgo(isoString) {
-  if (!isoString) return ''
-  const diff = (Date.now() - new Date(isoString).getTime()) / 1000
-  if (diff < 60)        return `${Math.floor(diff)}s`
-  if (diff < 3600)      return `${Math.floor(diff / 60)}m`
-  if (diff < 86400)     return `${Math.floor(diff / 3600)}h`
-  if (diff < 2592000)   return `${Math.floor(diff / 86400)}d`
-  return new Date(isoString).toLocaleDateString()
-}

--- a/frontend/src/pages/SocialFeedPage.jsx
+++ b/frontend/src/pages/SocialFeedPage.jsx
@@ -231,7 +231,12 @@ export default function SocialFeedPage() {
                 ? 'Bookmark posts from the feed to save inspiration for later.'
                 : vibeFilter
                 ? 'No posts tagged with this vibe yet. Be the first!'
-                : 'Be the first to publish an outfit from your Saved collection.'
+                : 'Be the first to share an outfit with the community!'
+            }
+            action={
+              tab === 'discover' && !vibeFilter
+                ? { label: 'Share an outfit →', onClick: () => navigate('/saved') }
+                : undefined
             }
           />
         )}

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -74,6 +74,17 @@ export function formatDate(isoString) {
   })
 }
 
+export function formatRelativeTime(isoString) {
+  if (!isoString) return ''
+  const diff = (Date.now() - new Date(isoString).getTime()) / 1000
+  if (diff < 60)      return 'just now'
+  if (diff < 3600)    return `${Math.floor(diff / 60)} min ago`
+  if (diff < 86400)   return `${Math.floor(diff / 3600)} hour${Math.floor(diff / 3600) !== 1 ? 's' : ''} ago`
+  if (diff < 172800)  return 'Yesterday'
+  if (diff < 604800)  return `${Math.floor(diff / 86400)} days ago`
+  return new Date(isoString).toLocaleDateString('en-PK', { month: 'short', day: 'numeric' })
+}
+
 export function getGreeting() {
   const hour = new Date().getHours()
   if (hour < 12) return 'Good morning'


### PR DESCRIPTION
## Summary
- **Trending badge**: Posts with ≥20 likes show a 🔥 Trending badge on the image
- **Relative time**: Upgraded from short format ("2h") to human-readable ("2 hours ago", "Yesterday", "3 days ago", "just now")
- **Remix count**: Always shows a number (was showing "Remix" text when 0)
- **Empty feed CTA**: Discover tab with no posts shows "Share an outfit →" button linking to /saved
- Added `formatRelativeTime()` to `formatters.js` (unit-testable utility)

## Changes
| File | Change |
|------|--------|
| `frontend/src/utils/formatters.js` | Added `formatRelativeTime()` |
| `frontend/src/components/social/FeedCard.jsx` | Trending badge, relative time, remix count, removed dead `_timeAgo` |
| `frontend/src/pages/SocialFeedPage.jsx` | Empty discover feed shows "Share an outfit →" CTA |

## Test steps
1. Social feed → any post card shows timestamp like "2 hours ago" or "Yesterday"
2. Remix count shows "0" instead of "Remix" on new posts
3. Empty discover tab shows "Share an outfit →" button
4. (To test trending: temporarily lower threshold or like a post 20 times — badge shows 🔥 Trending)

Closes #115