### PR TITLE
feat: bulk wardrobe actions — multi-select, delete, formality (#125)

### DIFF
--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -11,6 +11,8 @@ Routes (wardrobe_bp):
   GET    /wardrobe/items        — list all items for the authenticated user
   PATCH  /wardrobe/items/<id>   — correct category or formality after upload
   DELETE /wardrobe/items/<id>   — remove an item
+  DELETE /wardrobe/items/bulk   — bulk delete by item_ids
+  PATCH  /wardrobe/items/bulk   — bulk formality update by item_ids
   GET    /wardrobe/stats        — wardrobe statistics and insights
 
 Routes (uploads_bp, public — no JWT):
@@ -331,6 +333,78 @@ def edit_item(item_id: int):
 
     db.session.commit()
     return jsonify(item.to_dict()), 200
+
+
+# ─── DELETE /wardrobe/items/bulk ─────────────────────────────────────────────
+
+@wardrobe_bp.route("/items/bulk", methods=["DELETE"])
+@jwt_required()
+def bulk_delete_items():
+    """
+    DELETE /wardrobe/items/bulk
+    Body (JSON): { "item_ids": [1, 2, 3] }
+    Deletes all specified items that belong to the authenticated user.
+    Items not owned by the user are silently skipped (not an error).
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+    item_ids = data.get("item_ids", [])
+
+    if not item_ids or not isinstance(item_ids, list):
+        return jsonify({"error": "item_ids must be a non-empty list."}), 400
+
+    items = WardrobeItemDB.query.filter(
+        WardrobeItemDB.id.in_(item_ids),
+        WardrobeItemDB.user_id == user_id,
+    ).all()
+
+    deleted_count = 0
+    for item in items:
+        image_path = os.path.join(current_app.config["UPLOAD_FOLDER"], item.image_filename)
+        try:
+            if os.path.exists(image_path):
+                os.remove(image_path)
+        except OSError as exc:
+            logger.warning("Could not delete image file %s: %s", image_path, exc)
+        from app.storage import delete_file as storage_delete
+        storage_delete(item.image_filename)
+        db.session.delete(item)
+        deleted_count += 1
+
+    db.session.commit()
+    recommendation_cache.invalidate_user(user_id)
+    log_action("bulk_delete_items", user_id=user_id, detail=f"deleted={deleted_count}")
+    return jsonify({"deleted": deleted_count}), 200
+
+
+# ─── PATCH /wardrobe/items/bulk ──────────────────────────────────────────────
+
+@wardrobe_bp.route("/items/bulk", methods=["PATCH"])
+@jwt_required()
+def bulk_update_items():
+    """
+    PATCH /wardrobe/items/bulk
+    Body (JSON): { "item_ids": [1, 2, 3], "formality": "casual" }
+    Updates formality for all specified items that belong to the authenticated user.
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+    item_ids = data.get("item_ids", [])
+    formality = data.get("formality")
+
+    if not item_ids or not isinstance(item_ids, list):
+        return jsonify({"error": "item_ids must be a non-empty list."}), 400
+    if formality not in VALID_FORMALITIES:
+        return jsonify({"error": f"formality must be one of: {', '.join(VALID_FORMALITIES)}."}), 422
+
+    updated_count = WardrobeItemDB.query.filter(
+        WardrobeItemDB.id.in_(item_ids),
+        WardrobeItemDB.user_id == user_id,
+    ).update({"formality": formality}, synchronize_session=False)
+
+    db.session.commit()
+    log_action("bulk_update_items", user_id=user_id, detail=f"updated={updated_count} formality={formality}")
+    return jsonify({"updated": updated_count}), 200
 
 
 # ─── GET /wardrobe/stats ─────────────────────────────────────────────────────

--- a/frontend/src/api/wardrobe.js
+++ b/frontend/src/api/wardrobe.js
@@ -14,6 +14,12 @@ export const deleteItem = (id) =>
 export const patchItem = (id, data) =>
   api.patch(`/wardrobe/items/${id}`, data).then(r => r.data)
 
+export const bulkDeleteItems = (item_ids) =>
+  api.delete('/wardrobe/items/bulk', { data: { item_ids } }).then(r => r.data)
+
+export const bulkUpdateFormality = (item_ids, formality) =>
+  api.patch('/wardrobe/items/bulk', { item_ids, formality }).then(r => r.data)
+
 export const getWardrobeStats = () =>
   api.get('/wardrobe/stats').then(r => r.data)
 

--- a/frontend/src/components/wardrobe/WardrobeCard.jsx
+++ b/frontend/src/components/wardrobe/WardrobeCard.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
-import { FiEdit2, FiTrash2, FiStar, FiUser } from 'react-icons/fi'
+import { FiEdit2, FiTrash2, FiStar, FiUser, FiCheckCircle } from 'react-icons/fi'
 import { patchItem } from '../../api/wardrobe.js'
 import { resolveUrl } from '../../utils/resolveUrl.js'
 import ConfirmDialog from '../ui/ConfirmDialog.jsx'
@@ -16,7 +16,7 @@ const CAT_EMOJI = {
 const CATEGORIES = ['top', 'bottom', 'outwear', 'shoes', 'dress', 'jumpsuit']
 const FORMALITIES = ['casual', 'formal', 'both']
 
-export default function WardrobeCard({ item, onDelete }) {
+export default function WardrobeCard({ item, onDelete, selectMode = false, selected = false, onToggleSelect }) {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [tryOnOpen, setTryOnOpen] = useState(false)
@@ -47,7 +47,8 @@ export default function WardrobeCard({ item, onDelete }) {
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.3 }}
-        className="card overflow-hidden group"
+        className={`card overflow-hidden group cursor-pointer ${selected ? 'ring-2 ring-accent-500 ring-offset-2' : ''}`}
+        onClick={selectMode ? () => onToggleSelect?.(item.id) : undefined}
       >
         {/* Image */}
         <div className="relative aspect-square bg-brand-100/60 dark:bg-brand-800/40 overflow-hidden">
@@ -67,8 +68,18 @@ export default function WardrobeCard({ item, onDelete }) {
           {/* Overlay gradient */}
           <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
 
+          {/* Select mode overlay */}
+          {selectMode && (
+            <div className={`absolute inset-0 flex items-center justify-center transition-colors duration-200 ${selected ? 'bg-accent-500/20' : 'bg-transparent hover:bg-brand-900/10'}`}>
+              <FiCheckCircle
+                size={32}
+                className={`transition-all duration-200 ${selected ? 'text-accent-500 opacity-100' : 'text-white opacity-40'}`}
+              />
+            </div>
+          )}
+
           {/* Action buttons — always visible on touch, hover-only on desktop */}
-          <div className="absolute top-2 right-2 flex gap-1.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all duration-200 sm:translate-y-1 sm:group-hover:translate-y-0">
+          <div className={`absolute top-2 right-2 flex gap-1.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all duration-200 sm:translate-y-1 sm:group-hover:translate-y-0 ${selectMode ? 'hidden' : ''}`}>
             <button
               onClick={() => setIsEditing(true)}
               className="bg-white/90 dark:bg-brand-800/90 backdrop-blur-sm hover:bg-white dark:hover:bg-brand-700 text-brand-600 dark:text-brand-300 rounded-lg p-2 shadow-sm transition-colors"
@@ -165,18 +176,22 @@ export default function WardrobeCard({ item, onDelete }) {
             </div>
           )}
 
-          <button
-            onClick={() => navigate('/recommendations', { state: { anchorItemId: item.id } })}
-            className="w-full text-sm font-semibold py-2.5 rounded-lg btn-accent flex items-center justify-center gap-1.5 mb-2"
-          >
-            <FiStar size={13} /> Build outfit
-          </button>
-          <button
-            onClick={() => setTryOnOpen(true)}
-            className="w-full text-xs text-brand-500 dark:text-brand-400 font-medium py-2 border border-brand-200/60 dark:border-brand-700/40 rounded-lg hover:bg-brand-50/60 dark:hover:bg-brand-800/40 transition-all flex items-center justify-center gap-1.5"
-          >
-            <FiUser size={12} /> Virtual Try-On
-          </button>
+          {!selectMode && (
+            <>
+              <button
+                onClick={() => navigate('/recommendations', { state: { anchorItemId: item.id } })}
+                className="w-full text-sm font-semibold py-2.5 rounded-lg btn-accent flex items-center justify-center gap-1.5 mb-2"
+              >
+                <FiStar size={13} /> Build outfit
+              </button>
+              <button
+                onClick={() => setTryOnOpen(true)}
+                className="w-full text-xs text-brand-500 dark:text-brand-400 font-medium py-2 border border-brand-200/60 dark:border-brand-700/40 rounded-lg hover:bg-brand-50/60 dark:hover:bg-brand-800/40 transition-all flex items-center justify-center gap-1.5"
+              >
+                <FiUser size={12} /> Virtual Try-On
+              </button>
+            </>
+          )}
         </div>
       </motion.div>
 

--- a/frontend/src/components/wardrobe/WardrobeGrid.jsx
+++ b/frontend/src/components/wardrobe/WardrobeGrid.jsx
@@ -1,7 +1,7 @@
 import WardrobeCard from './WardrobeCard.jsx'
 import EmptyState from '../ui/EmptyState.jsx'
 
-export default function WardrobeGrid({ items, onDelete, onUpload }) {
+export default function WardrobeGrid({ items, onDelete, onUpload, selectMode, selectedIds, onToggleSelect }) {
   if (!items || items.length === 0) {
     return (
       <EmptyState
@@ -16,7 +16,14 @@ export default function WardrobeGrid({ items, onDelete, onUpload }) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
       {items.map(item => (
-        <WardrobeCard key={item.id} item={item} onDelete={onDelete} />
+        <WardrobeCard
+          key={item.id}
+          item={item}
+          onDelete={onDelete}
+          selectMode={selectMode}
+          selected={selectedIds?.has(item.id) ?? false}
+          onToggleSelect={onToggleSelect}
+        />
       ))}
     </div>
   )

--- a/frontend/src/pages/WardrobePage.jsx
+++ b/frontend/src/pages/WardrobePage.jsx
@@ -1,18 +1,23 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { motion } from 'framer-motion'
-import { FiPlus } from 'react-icons/fi'
-import { getItems, deleteItem } from '../api/wardrobe.js'
+import { motion, AnimatePresence } from 'framer-motion'
+import { FiPlus, FiCheckSquare, FiX, FiTrash2 } from 'react-icons/fi'
+import { getItems, deleteItem, bulkDeleteItems, bulkUpdateFormality } from '../api/wardrobe.js'
 import PageWrapper from '../components/layout/PageWrapper.jsx'
 import WardrobeGrid from '../components/wardrobe/WardrobeGrid.jsx'
 import UploadModal from '../components/wardrobe/UploadModal.jsx'
+import ConfirmDialog from '../components/ui/ConfirmDialog.jsx'
 import ErrorMessage from '../components/ui/ErrorMessage.jsx'
 
 const CATEGORIES = ['all', 'top', 'bottom', 'outwear', 'shoes', 'dress', 'jumpsuit']
+const FORMALITIES = ['casual', 'formal', 'both']
 
 export default function WardrobePage() {
   const [uploadOpen, setUploadOpen] = useState(false)
   const [filter, setFilter] = useState('all')
+  const [selectMode, setSelectMode] = useState(false)
+  const [selectedIds, setSelectedIds] = useState(new Set())
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false)
   const queryClient = useQueryClient()
 
   const { data, isLoading, error, refetch } = useQuery({
@@ -25,8 +30,43 @@ export default function WardrobePage() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['wardrobe'] }),
   })
 
+  const bulkDeleteMutation = useMutation({
+    mutationFn: (ids) => bulkDeleteItems([...ids]),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['wardrobe'] })
+      exitSelectMode()
+    },
+  })
+
+  const bulkFormalityMutation = useMutation({
+    mutationFn: ({ ids, formality }) => bulkUpdateFormality([...ids], formality),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['wardrobe'] })
+      exitSelectMode()
+    },
+  })
+
   const items = data?.items ?? []
   const filtered = filter === 'all' ? items : items.filter(i => i.category === filter)
+
+  function toggleSelect(id) {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  function exitSelectMode() {
+    setSelectMode(false)
+    setSelectedIds(new Set())
+  }
+
+  function selectAll() {
+    setSelectedIds(new Set(filtered.map(i => i.id)))
+  }
+
+  const selCount = selectedIds.size
 
   return (
     <>
@@ -42,10 +82,36 @@ export default function WardrobePage() {
               {isLoading ? 'Loading your wardrobe items...' : `${items.length} item${items.length !== 1 ? 's' : ''} in your collection`}
             </p>
           </div>
-          <button onClick={() => setUploadOpen(true)} className="btn-primary flex items-center gap-2 group">
-            <FiPlus size={16} />
-            <span className="hidden sm:inline">Upload</span>
-          </button>
+          <div className="flex items-center gap-2">
+            {selectMode ? (
+              <>
+                <button
+                  onClick={selCount === filtered.length ? () => setSelectedIds(new Set()) : selectAll}
+                  className="h-9 px-3 rounded-xl text-xs font-medium text-brand-500 dark:text-brand-400 border border-brand-200/60 dark:border-brand-700/40 hover:bg-brand-50 dark:hover:bg-brand-800/40 transition-all"
+                >
+                  {selCount === filtered.length ? 'Deselect All' : 'Select All'}
+                </button>
+                <button onClick={exitSelectMode} className="h-9 px-3 rounded-xl text-xs font-medium btn-secondary flex items-center gap-1.5">
+                  <FiX size={13} /> Done
+                </button>
+              </>
+            ) : (
+              <>
+                {items.length > 0 && (
+                  <button
+                    onClick={() => setSelectMode(true)}
+                    className="h-9 px-3 rounded-xl text-xs font-medium text-brand-500 dark:text-brand-400 border border-brand-200/60 dark:border-brand-700/40 hover:bg-brand-50 dark:hover:bg-brand-800/40 transition-all flex items-center gap-1.5"
+                  >
+                    <FiCheckSquare size={13} /> Select
+                  </button>
+                )}
+                <button onClick={() => setUploadOpen(true)} className="btn-primary flex items-center gap-2 group">
+                  <FiPlus size={16} />
+                  <span className="hidden sm:inline">Upload</span>
+                </button>
+              </>
+            )}
+          </div>
         </div>
 
         {/* Filter tabs */}
@@ -100,11 +166,61 @@ export default function WardrobePage() {
             items={filtered}
             onDelete={id => deleteMutation.mutate(id)}
             onUpload={() => setUploadOpen(true)}
+            selectMode={selectMode}
+            selectedIds={selectedIds}
+            onToggleSelect={toggleSelect}
           />
         )}
       </PageWrapper>
 
+      {/* Bulk action bar */}
+      <AnimatePresence>
+        {selectMode && selCount > 0 && (
+          <motion.div
+            initial={{ y: 100, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: 100, opacity: 0 }}
+            transition={{ type: 'spring', bounce: 0.2, duration: 0.4 }}
+            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 bg-brand-900 dark:bg-brand-100 text-white dark:text-brand-900 rounded-2xl shadow-2xl px-5 py-3"
+          >
+            <span className="text-sm font-semibold mr-1">{selCount} selected</span>
+
+            {/* Bulk formality */}
+            <div className="flex gap-1.5 border-l border-white/20 dark:border-brand-900/20 pl-3">
+              {FORMALITIES.map(f => (
+                <button
+                  key={f}
+                  onClick={() => bulkFormalityMutation.mutate({ ids: selectedIds, formality: f })}
+                  disabled={bulkFormalityMutation.isPending}
+                  className="h-8 px-3 rounded-lg text-xs font-medium bg-white/15 dark:bg-brand-900/15 hover:bg-white/25 dark:hover:bg-brand-900/25 capitalize transition-all disabled:opacity-50"
+                >
+                  {f}
+                </button>
+              ))}
+            </div>
+
+            {/* Bulk delete */}
+            <button
+              onClick={() => setConfirmBulkDelete(true)}
+              className="h-8 w-8 rounded-lg flex items-center justify-center bg-red-500/80 hover:bg-red-500 transition-all ml-1"
+              title="Delete selected"
+            >
+              <FiTrash2 size={14} />
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <UploadModal open={uploadOpen} onClose={() => setUploadOpen(false)} />
+
+      <ConfirmDialog
+        open={confirmBulkDelete}
+        title={`Delete ${selCount} item${selCount !== 1 ? 's' : ''}?`}
+        message={`Remove ${selCount} item${selCount !== 1 ? 's' : ''} from your wardrobe? This cannot be undone.`}
+        danger
+        onConfirm={() => { setConfirmBulkDelete(false); bulkDeleteMutation.mutate(selectedIds) }}
+        onCancel={() => setConfirmBulkDelete(false)}
+      />
     </>
   )
 }

--- a/tests/test_flask_wardrobe.py
+++ b/tests/test_flask_wardrobe.py
@@ -4,6 +4,8 @@ Tests for:
   POST   /wardrobe/items       — upload
   GET    /wardrobe/items       — list
   DELETE /wardrobe/items/<id>  — delete
+  DELETE /wardrobe/items/bulk  — bulk delete
+  PATCH  /wardrobe/items/bulk  — bulk formality update
   GET    /uploads/<filename>   — serve image (ownership check)
 """
 
@@ -439,3 +441,129 @@ class TestEditItem:
             headers=auth_headers,
         )
         assert resp.status_code == 400
+
+
+# ─── Bulk Delete ──────────────────────────────────────────────────────────────
+
+class TestBulkDelete:
+    def _upload(self, client, headers, minimal_png):
+        data = {
+            "image":     (io.BytesIO(minimal_png), "item.png", "image/png"),
+            "formality": "casual",
+            "gender":    "men",
+        }
+        r = client.post("/wardrobe/items", data=data, headers=headers,
+                        content_type="multipart/form-data")
+        assert r.status_code == 201
+        return r.get_json()["id"]
+
+    def test_bulk_delete_removes_items(self, client, auth_headers, minimal_png):
+        """Bulk-deleting two items removes exactly those two."""
+        id1 = self._upload(client, auth_headers, minimal_png)
+        id2 = self._upload(client, auth_headers, minimal_png)
+
+        resp = client.delete(
+            "/wardrobe/items/bulk",
+            json={"item_ids": [id1, id2]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["deleted"] == 2
+
+        # Verify they're gone
+        list_resp = client.get("/wardrobe/items", headers=auth_headers)
+        ids_remaining = [i["id"] for i in list_resp.get_json()["items"]]
+        assert id1 not in ids_remaining
+        assert id2 not in ids_remaining
+
+    def test_bulk_delete_ignores_other_users_items(self, client, auth_headers, minimal_png):
+        """Items belonging to another user are silently skipped."""
+        id1 = self._upload(client, auth_headers, minimal_png)
+
+        # Register user B
+        client.post("/auth/register", json={
+            "name": "User B", "email": "bulk_del_b@example.com",
+            "password": "password123", "gender": "men",
+        })
+        login_b = client.post("/auth/login", json={
+            "email": "bulk_del_b@example.com", "password": "password123",
+        })
+        headers_b = {"Authorization": f"Bearer {login_b.get_json()['access_token']}"}
+
+        # User B tries to bulk-delete user A's item
+        resp = client.delete(
+            "/wardrobe/items/bulk",
+            json={"item_ids": [id1]},
+            headers=headers_b,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["deleted"] == 0  # item not owned by B
+
+    def test_bulk_delete_missing_body(self, client, auth_headers):
+        """Missing item_ids → 400."""
+        resp = client.delete("/wardrobe/items/bulk", json={}, headers=auth_headers)
+        assert resp.status_code == 400
+
+
+# ─── Bulk Formality Update ────────────────────────────────────────────────────
+
+class TestBulkFormalityUpdate:
+    def _upload(self, client, headers, minimal_png, formality="casual"):
+        data = {
+            "image":     (io.BytesIO(minimal_png), "item.png", "image/png"),
+            "formality": formality,
+            "gender":    "men",
+        }
+        r = client.post("/wardrobe/items", data=data, headers=headers,
+                        content_type="multipart/form-data")
+        assert r.status_code == 201
+        return r.get_json()["id"]
+
+    def test_bulk_update_formality(self, client, auth_headers, minimal_png):
+        """Bulk update sets correct formality on all specified items."""
+        id1 = self._upload(client, auth_headers, minimal_png, formality="casual")
+        id2 = self._upload(client, auth_headers, minimal_png, formality="casual")
+
+        resp = client.patch(
+            "/wardrobe/items/bulk",
+            json={"item_ids": [id1, id2], "formality": "formal"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["updated"] == 2
+
+        # Verify formality changed
+        list_resp = client.get("/wardrobe/items", headers=auth_headers)
+        items = {i["id"]: i for i in list_resp.get_json()["items"]}
+        assert items[id1]["formality"] == "formal"
+        assert items[id2]["formality"] == "formal"
+
+    def test_bulk_update_invalid_formality(self, client, auth_headers, upload_item):
+        """Invalid formality value → 422."""
+        resp = client.patch(
+            "/wardrobe/items/bulk",
+            json={"item_ids": [upload_item["id"]], "formality": "smart_casual"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_bulk_update_other_users_items_skipped(self, client, auth_headers, minimal_png):
+        """Items belonging to another user are silently skipped."""
+        id1 = self._upload(client, auth_headers, minimal_png)
+
+        client.post("/auth/register", json={
+            "name": "User C", "email": "bulk_upd_c@example.com",
+            "password": "password123", "gender": "men",
+        })
+        login_c = client.post("/auth/login", json={
+            "email": "bulk_upd_c@example.com", "password": "password123",
+        })
+        headers_c = {"Authorization": f"Bearer {login_c.get_json()['access_token']}"}
+
+        resp = client.patch(
+            "/wardrobe/items/bulk",
+            json={"item_ids": [id1], "formality": "formal"},
+            headers=headers_c,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["updated"] == 0  # not owned by C


### PR DESCRIPTION
## Summary
- **Select mode**: "Select" button in header activates multi-select; each card shows a checkbox overlay
- **Select All / Deselect All** toggle button
- **Floating action bar**: appears at bottom when ≥1 items selected — shows count + formality buttons + delete
- **Bulk delete**: confirmation dialog → deletes selected items
- **Bulk formality**: one-tap update to Casual / Formal / Both for all selected items
- Normal card actions (Build outfit, Try-On, Edit) are hidden during select mode

## Backend
- `DELETE /wardrobe/items/bulk` — body `{ item_ids: [...] }` — returns `{ deleted: N }`
- `PATCH /wardrobe/items/bulk` — body `{ item_ids: [...], formality: "..." }` — returns `{ updated: N }`
- Both endpoints silently skip items not owned by the requesting user (isolation verified in tests)

## Tests (6 new, all passing)
- Bulk delete removes exactly the specified items
- Bulk delete ignores other users' items (returns deleted=0)
- Bulk delete with missing body → 400
- Bulk formality update sets correct formality on all items
- Bulk formality with invalid value → 422
- Bulk formality ignores other users' items (returns updated=0)

## Test steps
1. Wardrobe → "Select" button appears in header (only when items exist)
2. Click items to select — highlighted border + checkmark overlay
3. Action bar slides up from bottom showing "X selected" + Casual/Formal/Both buttons + 🗑
4. Tap "Formal" → all selected items update formality instantly
5. Tap 🗑 → confirmation dialog → items deleted
6. "Done" or empty selection hides the action bar

Closes #125