### PR TITLE
fix: require JWT on /uploads/<filename> endpoint (#128)

### DIFF
--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -15,8 +15,8 @@ Routes (wardrobe_bp):
   PATCH  /wardrobe/items/bulk   — bulk formality update by item_ids
   GET    /wardrobe/stats        — wardrobe statistics and insights
 
-Routes (uploads_bp, public — no JWT):
-  GET    /uploads/<filename>    — serve an uploaded image (404 if not in DB)
+Routes (uploads_bp — JWT required via header or ?token= param):
+  GET    /uploads/<filename>    — serve an uploaded image (401 if unauthed, 404 if not in DB)
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ import uuid
 from flask import (
     Blueprint, current_app, jsonify, redirect, request, send_from_directory,
 )
-from flask_jwt_extended import jwt_required, get_jwt_identity
+from flask_jwt_extended import jwt_required, get_jwt_identity, decode_token
 
 from app.extensions import limiter
 
@@ -530,18 +530,43 @@ def wardrobe_stats():
 @uploads_bp.route("/uploads/<string:filename>")
 def serve_upload(filename: str):
     """
-    GET /uploads/<filename>
+    GET /uploads/<filename>?token=<jwt>
+    Requires authentication via Authorization: Bearer header or ?token= query param.
     Redirects to Supabase CDN when configured, otherwise serves from local disk.
     """
+    from flask_jwt_extended import verify_jwt_in_request
     from app.storage import is_configured, get_public_url
+    from app.models_db import WardrobeItemDB
+
+    # Accept JWT from Authorization header or ?token= query param (<img src> compatibility)
+    token_param = request.args.get("token")
+    if token_param:
+        try:
+            decoded = decode_token(token_param)
+            user_id = decoded["sub"]
+        except Exception:
+            return jsonify(error="Invalid token"), 401
+    else:
+        try:
+            verify_jwt_in_request()
+            user_id = get_jwt_identity()
+        except Exception:
+            return jsonify(error="Authentication required"), 401
+
+    # Verify the file is owned by the requesting user
+    item = WardrobeItemDB.query.filter_by(
+        image_filename=filename, user_id=user_id
+    ).first()
+    if item is None:
+        return jsonify(error="Not found"), 404
 
     if is_configured():
         response = redirect(get_public_url(filename), code=302)
-        response.headers["Cache-Control"] = "public, max-age=86400"
+        response.headers["Cache-Control"] = "private, max-age=86400"
         return response
 
     # Fallback for local dev without Supabase
     upload_dir = current_app.config["UPLOAD_FOLDER"]
     response = send_from_directory(os.path.abspath(upload_dir), filename)
-    response.headers["Cache-Control"] = "public, max-age=86400"
+    response.headers["Cache-Control"] = "private, max-age=86400"
     return response

--- a/frontend/src/utils/resolveUrl.js
+++ b/frontend/src/utils/resolveUrl.js
@@ -3,5 +3,8 @@ const API_URL = import.meta.env.VITE_API_URL || ''
 export const resolveUrl = (url) => {
   if (!url) return null
   if (url.startsWith('http')) return url
-  return `${API_URL}${url}`
+  // Append JWT so the authenticated /uploads/ endpoint accepts <img src> requests
+  const token = localStorage.getItem('outfit_token')
+  const sep = url.includes('?') ? '&' : '?'
+  return `${API_URL}${url}${token ? `${sep}token=${encodeURIComponent(token)}` : ''}`
 }

--- a/tests/test_flask_wardrobe.py
+++ b/tests/test_flask_wardrobe.py
@@ -6,7 +6,7 @@ Tests for:
   DELETE /wardrobe/items/<id>  — delete
   DELETE /wardrobe/items/bulk  — bulk delete
   PATCH  /wardrobe/items/bulk  — bulk formality update
-  GET    /uploads/<filename>   — serve image (ownership check)
+  GET    /uploads/<filename>   — serve image (JWT required, ownership check)
 """
 
 from __future__ import annotations
@@ -356,19 +356,21 @@ class TestServeUpload:
         # File may not physically exist on disk in tests, but DB record exists → 200 or 404 from disk
         assert resp.status_code in (200, 404)
 
-    def test_serve_upload_no_auth(self, client, upload_item):
-        """After FIX 2: no JWT required — unauthenticated requests are allowed."""
+    def test_serve_upload_no_auth_returns_401(self, client, upload_item):
+        """Unauthenticated requests must be rejected — JWT now required."""
         image_url = upload_item["image_url"]
         filename = image_url.split("/uploads/")[1]
         resp = client.get(f"/uploads/{filename}")
-        if resp.status_code in (200, 302):
-            assert resp.headers.get("Cache-Control") == "public, max-age=86400"
-        # DB record exists, so not 401/403. File may not be on disk → 200 or 404.
-        assert resp.status_code in (200, 404)
+        assert resp.status_code == 401
 
-    def test_serve_upload_not_found(self, client):
-        """Filename not in DB → 404 (no auth needed)."""
+    def test_serve_upload_not_found_no_auth_returns_401(self, client):
+        """Auth check runs before existence check — unauthenticated → 401."""
         resp = client.get("/uploads/nonexistent_file_xyz.jpg")
+        assert resp.status_code == 401
+
+    def test_serve_upload_not_found_authed_returns_404(self, client, auth_headers):
+        """Authenticated request for nonexistent file → 404."""
+        resp = client.get("/uploads/nonexistent_file_xyz.jpg", headers=auth_headers)
         assert resp.status_code == 404
 
 


### PR DESCRIPTION
## Summary
- `/uploads/<filename>` now requires authentication — returns 401 for unauthenticated requests
- Accepts JWT via `Authorization: Bearer` header **or** `?token=<jwt>` query param so `<img src>` tags continue to work without XHR workarounds
- Verifies ownership: requested file must exist in `WardrobeItemDB` for the requesting user; returns 404 otherwise
- Frontend `resolveUrl()` now appends `?token=<jwt>` to all relative `/uploads/` URLs automatically
- `Cache-Control` changed from `public` to `private`

## Test plan
- [ ] `pytest tests/test_flask_wardrobe.py::TestServeUpload` — 4 tests pass (35/35 total)
- [ ] Open wardrobe in browser — images load normally
- [ ] Open recommendations page — outfit card images load normally
- [ ] Open dashboard — OOTD widget images load normally
- [ ] Log out, open direct `/uploads/<filename>` URL → returns `{"error": "Authentication required"}` with 401

Closes #128