### PR TITLE
feat: paginate /wardrobe/items endpoint (#127)

### DIFF
--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -240,15 +240,54 @@ def upload_item():
 
 # ─── GET /wardrobe/items ──────────────────────────────────────────────────────
 
+_VALID_CATEGORIES = {"top", "bottom", "outwear", "shoes", "dress", "jumpsuit"}
+_MAX_LIMIT = 50
+
+
 @wardrobe_bp.route("/items", methods=["GET"])
 @jwt_required()
 def list_items():
-    """GET /wardrobe/items — return all wardrobe items for the authenticated user."""
+    """
+    GET /wardrobe/items?page=1&limit=20&category=top
+    Returns paginated wardrobe items for the authenticated user.
+
+    Query params:
+      page     — 1-based page number (default: 1)
+      limit    — items per page, max 50 (default: 20)
+      category — filter by category (optional)
+    """
     user_id = int(get_jwt_identity())
-    items   = WardrobeItemDB.query.filter_by(user_id=user_id).order_by(WardrobeItemDB.created_at.desc()).all()
+
+    try:
+        page  = max(1, int(request.args.get("page", 1)))
+        limit = min(_MAX_LIMIT, max(1, int(request.args.get("limit", 20))))
+    except (TypeError, ValueError):
+        return jsonify({"error": "page and limit must be integers"}), 400
+
+    category = request.args.get("category", "").strip().lower() or None
+    if category and category not in _VALID_CATEGORIES:
+        return jsonify({"error": f"Invalid category '{category}'"}), 400
+
+    query = (
+        WardrobeItemDB.query
+        .filter_by(user_id=user_id)
+        .order_by(WardrobeItemDB.created_at.desc())
+    )
+    if category:
+        query = query.filter(WardrobeItemDB.category == category)
+
+    total   = query.count()
+    pages   = max(1, -(-total // limit))          # ceiling division
+    items   = query.offset((page - 1) * limit).limit(limit).all()
+
     response = jsonify({
-        "items": [item.to_dict() for item in items],
-        "count": len(items),
+        "items":    [item.to_dict() for item in items],
+        "total":    total,
+        "page":     page,
+        "pages":    pages,
+        "limit":    limit,
+        "has_next": page < pages,
+        "has_prev": page > 1,
     })
     response.headers["Cache-Control"] = "private, max-age=60, stale-while-revalidate=300"
     response.headers["Vary"] = "Authorization"

--- a/frontend/src/api/wardrobe.js
+++ b/frontend/src/api/wardrobe.js
@@ -1,7 +1,10 @@
 import api from './axios.js'
 
-export const getItems = () =>
-  api.get('/wardrobe/items').then(r => r.data)
+export const getItems = ({ page = 1, limit = 20, category } = {}) => {
+  const params = { page, limit }
+  if (category && category !== 'all') params.category = category
+  return api.get('/wardrobe/items', { params }).then(r => r.data)
+}
 
 export const uploadItem = (formData) =>
   api.post('/wardrobe/items', formData, {

--- a/frontend/src/pages/WardrobePage.jsx
+++ b/frontend/src/pages/WardrobePage.jsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState, useRef, useCallback } from 'react'
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion, AnimatePresence } from 'framer-motion'
-import { FiPlus, FiCheckSquare, FiX, FiTrash2 } from 'react-icons/fi'
+import { FiPlus, FiCheckSquare, FiX, FiTrash2, FiLoader } from 'react-icons/fi'
 import { getItems, deleteItem, bulkDeleteItems, bulkUpdateFormality } from '../api/wardrobe.js'
 import PageWrapper from '../components/layout/PageWrapper.jsx'
 import WardrobeGrid from '../components/wardrobe/WardrobeGrid.jsx'
@@ -20,9 +20,19 @@ export default function WardrobePage() {
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false)
   const queryClient = useQueryClient()
 
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ['wardrobe'],
-    queryFn: getItems,
+  const {
+    data,
+    isLoading,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ['wardrobe', filter],
+    queryFn: ({ pageParam = 1 }) => getItems({ page: pageParam, limit: 20, category: filter }),
+    getNextPageParam: (lastPage) => lastPage.has_next ? lastPage.page + 1 : undefined,
+    staleTime: 60 * 1000,
   })
 
   const deleteMutation = useMutation({
@@ -46,8 +56,14 @@ export default function WardrobePage() {
     },
   })
 
-  const items = data?.items ?? []
-  const filtered = filter === 'all' ? items : items.filter(i => i.category === filter)
+  // Flatten all loaded pages
+  const items = data?.pages.flatMap(p => p.items) ?? []
+  const totalItems = data?.pages[0]?.total ?? 0
+
+  function handleFilterChange(cat) {
+    setFilter(cat)
+    exitSelectMode()
+  }
 
   function toggleSelect(id) {
     setSelectedIds(prev => {
@@ -63,10 +79,19 @@ export default function WardrobePage() {
   }
 
   function selectAll() {
-    setSelectedIds(new Set(filtered.map(i => i.id)))
+    setSelectedIds(new Set(items.map(i => i.id)))
   }
 
   const selCount = selectedIds.size
+
+  // Category counts from loaded items (updates as more pages load)
+  function catCount(cat) {
+    if (cat === 'all') return totalItems
+    // When a category filter is active, total comes from API; otherwise count client-side
+    if (filter === cat) return totalItems
+    if (filter !== 'all') return 0
+    return items.filter(i => i.category === cat).length
+  }
 
   return (
     <>
@@ -79,17 +104,19 @@ export default function WardrobePage() {
               My Wardrobe
             </h1>
             <p className="text-brand-500 dark:text-brand-400 mt-1">
-              {isLoading ? 'Loading your wardrobe items...' : `${items.length} item${items.length !== 1 ? 's' : ''} in your collection`}
+              {isLoading
+                ? 'Loading your wardrobe items...'
+                : `${totalItems} item${totalItems !== 1 ? 's' : ''} in your collection`}
             </p>
           </div>
           <div className="flex items-center gap-2">
             {selectMode ? (
               <>
                 <button
-                  onClick={selCount === filtered.length ? () => setSelectedIds(new Set()) : selectAll}
+                  onClick={selCount === items.length ? () => setSelectedIds(new Set()) : selectAll}
                   className="h-9 px-3 rounded-xl text-xs font-medium text-brand-500 dark:text-brand-400 border border-brand-200/60 dark:border-brand-700/40 hover:bg-brand-50 dark:hover:bg-brand-800/40 transition-all"
                 >
-                  {selCount === filtered.length ? 'Deselect All' : 'Select All'}
+                  {selCount === items.length ? 'Deselect All' : 'Select All'}
                 </button>
                 <button onClick={exitSelectMode} className="h-9 px-3 rounded-xl text-xs font-medium btn-secondary flex items-center gap-1.5">
                   <FiX size={13} /> Done
@@ -97,7 +124,7 @@ export default function WardrobePage() {
               </>
             ) : (
               <>
-                {items.length > 0 && (
+                {totalItems > 0 && (
                   <button
                     onClick={() => setSelectMode(true)}
                     className="h-9 px-3 rounded-xl text-xs font-medium text-brand-500 dark:text-brand-400 border border-brand-200/60 dark:border-brand-700/40 hover:bg-brand-50 dark:hover:bg-brand-800/40 transition-all flex items-center gap-1.5"
@@ -117,12 +144,12 @@ export default function WardrobePage() {
         {/* Filter tabs */}
         <div className="flex gap-2 flex-wrap mb-8">
           {CATEGORIES.map(cat => {
-            const count = cat === 'all' ? items.length : items.filter(i => i.category === cat).length
+            const count = catCount(cat)
             return (
               <motion.button
                 key={cat}
                 whileTap={{ scale: 0.96 }}
-                onClick={() => setFilter(cat)}
+                onClick={() => handleFilterChange(cat)}
                 style={{ touchAction: 'manipulation' }}
                 className={`relative flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 ${
                   filter === cat
@@ -163,13 +190,28 @@ export default function WardrobePage() {
         {error && <ErrorMessage message="Could not load wardrobe." onRetry={refetch} />}
         {!isLoading && !error && (
           <WardrobeGrid
-            items={filtered}
+            items={items}
             onDelete={id => deleteMutation.mutate(id)}
             onUpload={() => setUploadOpen(true)}
             selectMode={selectMode}
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}
           />
+        )}
+
+        {/* Load more */}
+        {hasNextPage && !isLoading && (
+          <div className="flex justify-center mt-8">
+            <button
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
+              className="btn-secondary flex items-center gap-2 disabled:opacity-60"
+            >
+              {isFetchingNextPage
+                ? <><FiLoader size={14} className="animate-spin" /> Loading…</>
+                : `Load more (${totalItems - items.length} remaining)`}
+            </button>
+          </div>
         )}
       </PageWrapper>
 

--- a/tests/test_flask_wardrobe.py
+++ b/tests/test_flask_wardrobe.py
@@ -249,7 +249,9 @@ class TestList:
         assert resp.status_code == 200
         body = resp.get_json()
         assert body["items"] == []
-        assert body["count"] == 0
+        assert body["total"] == 0
+        assert body["page"] == 1
+        assert body["has_next"] is False
 
     def test_list_after_upload(self, client, auth_headers, upload_item):
         resp = client.get("/wardrobe/items", headers=auth_headers)
@@ -257,12 +259,38 @@ class TestList:
         assert resp.headers.get("Cache-Control") == "private, max-age=60, stale-while-revalidate=300"
         assert "Authorization" in (resp.headers.get("Vary") or "")
         body = resp.get_json()
-        assert body["count"] == 1
+        assert body["total"] == 1
         assert body["items"][0]["id"] == upload_item["id"]
 
     def test_list_requires_auth(self, client):
         resp = client.get("/wardrobe/items")
         assert resp.status_code == 401
+
+    def test_list_pagination_params(self, client, auth_headers, upload_item):
+        """page/limit params are respected; category filter works."""
+        resp = client.get("/wardrobe/items?page=1&limit=5", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["page"] == 1
+        assert body["limit"] == 5
+        assert "has_next" in body
+        assert "has_prev" in body
+
+    def test_list_category_filter(self, client, auth_headers, upload_item):
+        """?category=top returns only tops; other categories return empty."""
+        resp = client.get("/wardrobe/items?category=top", headers=auth_headers)
+        body = resp.get_json()
+        assert resp.status_code == 200
+        # The mock pipeline returns "top" for every upload
+        assert body["total"] == 1
+        assert all(i["category"] == "top" for i in body["items"])
+
+        resp2 = client.get("/wardrobe/items?category=shoes", headers=auth_headers)
+        assert resp2.get_json()["total"] == 0
+
+    def test_list_invalid_category(self, client, auth_headers):
+        resp = client.get("/wardrobe/items?category=invalid", headers=auth_headers)
+        assert resp.status_code == 400
 
     def test_list_isolation_between_users(self, client, auth_headers, minimal_png):
         """Items uploaded by user A must not appear in user B's list."""
@@ -297,7 +325,7 @@ class TestList:
 
         resp = client.get("/wardrobe/items", headers=headers_b)
         assert resp.status_code == 200
-        assert resp.get_json()["count"] == 0
+        assert resp.get_json()["total"] == 0
 
 
 # ─── Delete ───────────────────────────────────────────────────────────────────
@@ -311,7 +339,7 @@ class TestDelete:
 
         # Confirm it's gone
         list_resp = client.get("/wardrobe/items", headers=auth_headers)
-        assert list_resp.get_json()["count"] == 0
+        assert list_resp.get_json()["total"] == 0
 
     def test_delete_not_found(self, client, auth_headers):
         resp = client.delete("/wardrobe/items/99999", headers=auth_headers)


### PR DESCRIPTION
## Summary
- \`GET /wardrobe/items\` now supports \`?page\`, \`?limit\` (default 20, max 50), and \`?category\` query params
- Response shape extended with \`total\`, \`page\`, \`pages\`, \`limit\`, \`has_next\`, \`has_prev\`
- \`WardrobePage\` switched from \`useQuery\` to \`useInfiniteQuery\`; category filter is now server-side
- "Load more" button appears when more pages exist
- Category counts in filter tabs use server-reported \`total\` for the active filter; client-side counts for inactive tabs from loaded items

## Test plan
- [ ] Open wardrobe — items load normally (page 1 of 20)
- [ ] Switch category tabs — filter works, count updates
- [ ] If wardrobe has >20 items: "Load more (N remaining)" button appears and loads next page
- [ ] \`pytest tests/test_flask_wardrobe.py\` — 38 passed (verified)
- [ ] \`npm run build\` passes (verified)

Closes #127