### PR TITLE
perf: image optimization pipeline — max_side 1500→800, normalize fallback uploads (#109)

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -6,6 +6,7 @@ Shared helper functions for the Flask layer.
   validate_image_content()    — Pillow verify() to reject non-image files
   validate_clothing_photo()   — confidence threshold check (≥0.45)
   item_db_to_engine()         — convert WardrobeItemDB → engine WardrobeItem
+  normalize_upload()          — EXIF+resize+JPEG for fallback (atelier failed)
   process_image_for_atelier() — normalise uploaded image to clean RGB PNG
 """
 
@@ -14,6 +15,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -135,18 +137,58 @@ def item_db_to_engine(item_db) -> "WardrobeItem":  # noqa: F821
     )
 
 
+def normalize_upload(path: str, max_side: int = 800, jpeg_quality: int = 85) -> None:
+    """
+    Lightweight normalisation for uploads that bypass the full Atelier pipeline.
+
+    Applies EXIF rotation correction, caps the longest side to `max_side`, and
+    re-encodes as JPEG (quality=`jpeg_quality`) in-place.  Replaces the original
+    file — so a 5-8 MB phone photo becomes a ~100-300 KB web-ready image.
+
+    Silently no-ops on any error so the upload is never blocked.
+    """
+    try:
+        from PIL import Image, ImageOps
+
+        img = Image.open(path)
+        img = ImageOps.exif_transpose(img)
+
+        w, h = img.size
+        if max(w, h) > max_side:
+            scale = max_side / max(w, h)
+            img = img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+
+        if img.mode in ("RGBA", "LA", "P"):
+            img = img.convert("RGB")
+        elif img.mode != "RGB":
+            img = img.convert("RGB")
+
+        # Replace in-place with a JPEG; rename path to .jpg
+        base, _ = os.path.splitext(path)
+        jpg_path = base + ".jpg"
+        img.save(jpg_path, "JPEG", quality=jpeg_quality, optimize=True)
+        if jpg_path != path:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+        logger.info("normalize_upload: saved %s (%dx%d)", jpg_path, img.width, img.height)
+    except Exception as exc:
+        logger.warning("normalize_upload: failed for %s — %s", path, exc)
+
+
 def process_image_for_atelier(
     src_path: str,
     dst_path: str,
-    max_side: int = 1500,
+    max_side: int = 800,
 ) -> tuple[bool, bool]:
     """
     Normalise an uploaded clothing image for the Atelier digital-closet experience.
 
     Pipeline (in order):
       1. Open image and apply EXIF orientation correction.
-      2. Cap the longest side to `max_side` pixels (speed guard — rembg on CPU is
-         O(pixels); a 20 MP phone photo would otherwise block the request ~30 s).
+      2. Cap the longest side to `max_side` pixels (default 800 — sufficient for
+         Retina card display; rembg on CPU is O(pixels) so smaller = faster).
       3. Attempt background removal via rembg (u2net model, self-hosted, ~176 MB).
          Uses already-decoded bytes — no second disk read.
       4. Composite the RGBA result onto a clean white RGB background so every

--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -39,7 +39,7 @@ from app.audit import log_action
 from app.cache import recommendation_cache
 from app.extensions import db
 from app.models_db import WardrobeItemDB, OutfitHistory, OutfitFeedback, SavedOutfit
-from app.utils import allowed_file, validate_image_content, validate_clothing_photo, process_image_for_atelier
+from app.utils import allowed_file, validate_image_content, validate_clothing_photo, process_image_for_atelier, normalize_upload
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +153,14 @@ def upload_item():
         )
     else:
         bg_removed = False
-        logger.warning("Atelier: processing failed for %s — using original.", filename)
+        logger.warning("Atelier: processing failed for %s — normalising original.", filename)
+        normalize_upload(save_path)
+        # normalize_upload may rename .jpg extension; find actual saved file
+        base, _ = os.path.splitext(save_path)
+        jpg_path = base + ".jpg"
+        if jpg_path != save_path and os.path.exists(jpg_path):
+            filename  = os.path.basename(jpg_path)
+            save_path = jpg_path
 
     # ── 5c. CLIP Zero-Shot OOD Detection ──────────────────────────────────────
     if not current_app.config.get("SKIP_CLOTHING_PHOTO_CHECK"):

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,0 +1,149 @@
+"""
+tests/test_image_processing.py
+Tests for app.utils image helpers:
+  normalize_upload()          — EXIF+resize+JPEG fallback normalisation
+  process_image_for_atelier() — max_side default reduced to 800
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+import tempfile
+import zlib
+
+import pytest
+from PIL import Image
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _make_png(width: int, height: int) -> bytes:
+    """Return a minimal valid PNG of the given dimensions (white RGB)."""
+    img = Image.new("RGB", (width, height), (255, 255, 255))
+    buf = __import__("io").BytesIO()
+    img.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _make_jpeg(width: int, height: int) -> bytes:
+    img = Image.new("RGB", (width, height), (200, 150, 100))
+    buf = __import__("io").BytesIO()
+    img.save(buf, "JPEG", quality=80)
+    return buf.getvalue()
+
+
+def _write_tmp(data: bytes, suffix: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    with open(path, "wb") as f:
+        f.write(data)
+    return path
+
+
+# ─── normalize_upload ─────────────────────────────────────────────────────────
+
+class TestNormalizeUpload:
+    """normalize_upload() must EXIF-correct, resize, and convert to JPEG in-place."""
+
+    def test_large_png_is_shrunk_to_800(self, tmp_path):
+        """A 1600×1200 PNG must be shrunk so longest side ≤ 800."""
+        from app.utils import normalize_upload
+
+        path = str(tmp_path / "large.png")
+        Image.new("RGB", (1600, 1200), (100, 100, 100)).save(path, "PNG")
+
+        normalize_upload(path, max_side=800)
+
+        # Original path is gone; a .jpg should exist
+        jpg_path = str(tmp_path / "large.jpg")
+        assert os.path.exists(jpg_path), "Expected .jpg output"
+        img = Image.open(jpg_path)
+        assert max(img.size) <= 800
+
+    def test_small_image_unchanged_dimensions(self, tmp_path):
+        """An image already within 800px must not be upscaled."""
+        from app.utils import normalize_upload
+
+        path = str(tmp_path / "small.png")
+        Image.new("RGB", (400, 300), (50, 50, 50)).save(path, "PNG")
+
+        normalize_upload(path, max_side=800)
+
+        jpg_path = str(tmp_path / "small.jpg")
+        img = Image.open(jpg_path)
+        assert img.size == (400, 300)
+
+    def test_aspect_ratio_preserved(self, tmp_path):
+        """Resize must preserve aspect ratio (no stretching)."""
+        from app.utils import normalize_upload
+
+        path = str(tmp_path / "wide.png")
+        Image.new("RGB", (2000, 500), (80, 80, 80)).save(path, "PNG")
+
+        normalize_upload(path, max_side=800)
+
+        jpg_path = str(tmp_path / "wide.jpg")
+        img = Image.open(jpg_path)
+        w, h = img.size
+        # Original ratio: 4:1 → after cap: 800×200
+        assert w == 800
+        assert h == 200
+
+    def test_rgba_converted_to_rgb(self, tmp_path):
+        """RGBA images must be converted to RGB (JPEG cannot encode alpha)."""
+        from app.utils import normalize_upload
+
+        path = str(tmp_path / "rgba.png")
+        Image.new("RGBA", (100, 100), (255, 0, 0, 128)).save(path, "PNG")
+
+        normalize_upload(path, max_side=800)
+
+        jpg_path = str(tmp_path / "rgba.jpg")
+        img = Image.open(jpg_path)
+        assert img.mode == "RGB"
+
+    def test_corrupt_file_does_not_raise(self, tmp_path):
+        """normalize_upload must silently no-op on corrupt input."""
+        from app.utils import normalize_upload
+
+        path = str(tmp_path / "bad.png")
+        with open(path, "wb") as f:
+            f.write(b"not an image at all")
+
+        # Must not raise
+        normalize_upload(path, max_side=800)
+
+
+# ─── process_image_for_atelier max_side default ───────────────────────────────
+
+class TestProcessImageAtelierMaxSide:
+    """process_image_for_atelier() default max_side must be 800 (not 1500)."""
+
+    def test_default_max_side_is_800(self, tmp_path):
+        """A 1600px image processed with defaults must produce ≤ 800px output."""
+        from app.utils import process_image_for_atelier
+
+        src = str(tmp_path / "big.png")
+        dst = str(tmp_path / "big_atelier.png")
+        Image.new("RGB", (1600, 1200), (200, 200, 200)).save(src, "PNG")
+
+        ok, _ = process_image_for_atelier(src, dst)
+
+        assert ok is True
+        img = Image.open(dst)
+        assert max(img.size) <= 800, f"Expected ≤800 but got {img.size}"
+
+    def test_explicit_max_side_override(self, tmp_path):
+        """max_side parameter must be respected when passed explicitly."""
+        from app.utils import process_image_for_atelier
+
+        src = str(tmp_path / "big2.png")
+        dst = str(tmp_path / "big2_atelier.png")
+        Image.new("RGB", (600, 400), (100, 100, 100)).save(src, "PNG")
+
+        ok, _ = process_image_for_atelier(src, dst, max_side=300)
+
+        assert ok is True
+        img = Image.open(dst)
+        assert max(img.size) <= 300


### PR DESCRIPTION
## Summary
- `process_image_for_atelier`: default `max_side` reduced from 1500 → 800 px (sufficient for Retina card display, ~56% fewer pixels → meaningfully faster rembg on CPU)
- New `normalize_upload(path, max_side=800, jpeg_quality=85)`: applied when atelier fails — EXIF-corrects, resizes, and re-encodes the original file as JPEG in-place, replacing raw 5–8 MB phone photos with ~100–300 KB web-ready files
- `wardrobe/routes.py`: calls `normalize_upload()` in the failure branch and handles any `.jpg` rename so the DB row gets the correct filename

## Test plan
- [x] `tests/test_image_processing.py` — 7 new tests: resize, aspect ratio preservation, RGBA→RGB, corrupt-file no-op, max_side default verification
- [x] Full wardrobe suite (`test_flask_wardrobe.py`) — 38/38 pass
- [x] Pre-push hook (pytest 158 tests) — all green

Closes #109