### PR TITLE
fix: replace chmod 777 with non-root appuser on uploads/instance (#100)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,16 @@ COPY migrations/ migrations/
 COPY run.py .
 COPY entrypoint.sh .
 
-# Runtime directories
-RUN mkdir -p uploads instance && chmod 777 uploads instance
-RUN chmod +x entrypoint.sh
+# Non-root app user — UID 1000 matches HF Spaces runtime expectation
+RUN groupadd -r appuser && useradd -r -g appuser -u 1000 appuser
+
+# Runtime directories — owned by app user, no world-write
+RUN mkdir -p uploads instance \
+    && chown -R appuser:appuser uploads instance \
+    && chmod 755 uploads instance \
+    && chmod +x entrypoint.sh
+
+USER appuser
 
 # Hugging Face Spaces default port
 EXPOSE 7860


### PR DESCRIPTION
## Summary
- Replaces `chmod 777` with a dedicated non-root `appuser` (UID 1000)
- `uploads/` and `instance/` are `chown`ed to appuser with `chmod 755`
- Container runs as non-root (`USER appuser`) at runtime

## Why UID 1000
HF Spaces runs Docker containers with UID 1000 by default. Creating `appuser` at the same UID ensures the runtime process can still write to the owned directories without world-write permissions.

## Test plan
- [x] Pre-push hook (pytest full suite) — all green
- [ ] `docker build .` — no errors
- [ ] `docker run` → Flask starts, `POST /wardrobe/items` writes file to `uploads/`
- [ ] HF Spaces deploy — app functions, uploads writable

Closes #100