### PR TITLE
a11y: descriptive alt text on all wardrobe item images (#105)

### DIFF
--- a/frontend/src/components/calendar/CalendarGrid.jsx
+++ b/frontend/src/components/calendar/CalendarGrid.jsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion'
 import { FiBriefcase, FiSun } from 'react-icons/fi'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 const OCCASION_ICON = {
@@ -92,7 +93,7 @@ export default function CalendarGrid({ year, month, plans, onDayClick }) {
                     {plan.items?.slice(0, 2).map((item, j) => (
                       <div key={j} className="w-4 h-4 sm:w-5 sm:h-5 rounded overflow-hidden bg-brand-100 dark:bg-brand-800 flex-shrink-0">
                         {item.image_url && (
-                          <img src={resolveUrl(item.image_url)} alt="" className="w-full h-full object-cover" />
+                          <img src={resolveUrl(item.image_url)} alt={wardrobeItemAlt(item)} className="w-full h-full object-cover" />
                         )}
                       </div>
                     ))}

--- a/frontend/src/components/calendar/PlanModal.jsx
+++ b/frontend/src/components/calendar/PlanModal.jsx
@@ -8,6 +8,7 @@ import { getItems } from '../../api/wardrobe.js'
 import { createPlan, updatePlan, deletePlan } from '../../api/calendar.js'
 import ConfirmDialog from '../ui/ConfirmDialog.jsx'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 
 const OCCASIONS = [
   { val: 'casual', label: 'Casual', Icon: FiSun },
@@ -237,7 +238,7 @@ export default function PlanModal({ open, date, existingPlan, monthStr, onClose 
                         <div className="flex gap-0.5 flex-shrink-0">
                           {outfit.items?.slice(0, 3).map((item, j) => (
                             <div key={j} className="w-8 h-8 rounded-lg overflow-hidden bg-brand-100 dark:bg-brand-800">
-                              {item.image_url && <img src={resolveUrl(item.image_url)} alt="" className="w-full h-full object-cover" />}
+                              {item.image_url && <img src={resolveUrl(item.image_url)} alt={wardrobeItemAlt(item)} className="w-full h-full object-cover" />}
                             </div>
                           ))}
                         </div>
@@ -266,7 +267,7 @@ export default function PlanModal({ open, date, existingPlan, monthStr, onClose 
                               : 'border-brand-100/60 dark:border-brand-800/40 hover:border-brand-300 dark:hover:border-brand-600'
                           }`}
                         >
-                          {item.image_url && <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />}
+                          {item.image_url && <img src={resolveUrl(item.image_url)} alt={wardrobeItemAlt(item)} className="w-full h-full object-cover" />}
                           {selected && (
                             <div className="absolute top-1 right-1 w-5 h-5 bg-accent-500 rounded-full flex items-center justify-center shadow-sm">
                               <FiCheck size={12} className="text-white" />

--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -10,6 +10,7 @@ import ConfidenceBadge from '../ui/ConfidenceBadge.jsx'
 import ScoreInfoTooltip from '../ui/ScoreInfoTooltip.jsx'
 import RetryImage from '../ui/RetryImage.jsx'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 import LiveRegion from '../ui/LiveRegion.jsx'
 
 export default function OOTDWidget() {
@@ -148,7 +149,7 @@ export default function OOTDWidget() {
               <div className="w-20 h-20 rounded-xl overflow-hidden bg-brand-100/60 dark:bg-brand-800/40 border border-brand-100/60 dark:border-brand-700/40 shadow-sm flex items-center justify-center">
                 <RetryImage
                   src={resolveUrl(item.image_url)}
-                  alt={item.category}
+                  alt={wardrobeItemAlt(item)}
                   loading="lazy"
                   decoding="async"
                   className="w-full h-full object-cover"

--- a/frontend/src/components/recommendations/OutfitItems.jsx
+++ b/frontend/src/components/recommendations/OutfitItems.jsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 import RetryImage from '../ui/RetryImage.jsx'
 
 const CAT_EMOJI = { top: '\u{1F455}', bottom: '\u{1F456}', outwear: '\u{1F9E5}', shoes: '\u{1F45F}', dress: '\u{1F457}', jumpsuit: '\u{1F938}' }
@@ -26,7 +27,7 @@ export default function OutfitItems({ items }) {
               
               <RetryImage
                 src={imageUrl}
-                alt={item.category}
+                alt={wardrobeItemAlt(item)}
                 loading="lazy"
                 decoding="async"
                 className="w-full h-full object-cover"

--- a/frontend/src/components/social/PostDetailModal.jsx
+++ b/frontend/src/components/social/PostDetailModal.jsx
@@ -8,6 +8,7 @@ import { useAuth } from '../../context/AuthContext.jsx'
 import VibeTagPill from './VibeTagPill.jsx'
 import OutfitTryOnModal from '../tryon/OutfitTryOnModal.jsx'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 
 export default function PostDetailModal({ post, open, onClose, onRemixClick, onVibeClick }) {
   const { user } = useAuth()
@@ -186,7 +187,7 @@ export default function PostDetailModal({ post, open, onClose, onRemixClick, onV
                     {fullPost.items.map((item, i) => (
                       <div key={i} className="aspect-square rounded-lg overflow-hidden bg-brand-100 dark:bg-brand-800 border border-brand-200 dark:border-brand-700">
                         {item.image_url ? (
-                          <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />
+                          <img src={resolveUrl(item.image_url)} alt={wardrobeItemAlt(item)} className="w-full h-full object-cover" />
                         ) : (
                           <div className="w-full h-full flex items-center justify-center text-xl opacity-30">
                             <span className="select-none">?</span>

--- a/frontend/src/components/tryon/OutfitTryOnModal.jsx
+++ b/frontend/src/components/tryon/OutfitTryOnModal.jsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { FiX, FiUser } from 'react-icons/fi'
 import TryOnModal from './TryOnModal.jsx'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 
 // Hero priority — most visually impactful garments first
 const HERO_PRIORITY = ['dress', 'jumpsuit', 'top', 'outwear', 'bottom', 'shoes']
@@ -99,7 +100,7 @@ export default function OutfitTryOnModal({ open, onClose, items, occasion }) {
                   >
                     <img
                       src={imgUrl}
-                      alt={item.category}
+                      alt={wardrobeItemAlt(item)}
                       className="w-full h-full object-cover"
                     />
 

--- a/frontend/src/components/tryon/TryOnModal.jsx
+++ b/frontend/src/components/tryon/TryOnModal.jsx
@@ -6,6 +6,7 @@ import { FiX, FiUploadCloud, FiUser, FiRefreshCw, FiCheck, FiAlertTriangle, FiDo
 import { getPersonPhoto, uploadPersonPhoto, submitTryOn, getJobStatus } from '../../api/vto.js'
 import LoadingSpinner from '../ui/LoadingSpinner.jsx'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 
 const POLL_INTERVAL_MS = 3000
 
@@ -284,7 +285,7 @@ export default function TryOnModal({ open, onClose, item }) {
                     <p className="label-xs mb-2">{item.category} to try</p>
                     <div className="aspect-[3/4] rounded-2xl overflow-hidden bg-brand-50 dark:bg-brand-800/60 border border-brand-200/60 dark:border-brand-700/40">
                       {itemImageUrl
-                        ? <img src={itemImageUrl} alt={item.category} className="w-full h-full object-cover" />
+                        ? <img src={itemImageUrl} alt={wardrobeItemAlt(item)} className="w-full h-full object-cover" />
                         : <div className="w-full h-full flex items-center justify-center text-brand-500 text-4xl">👕</div>
                       }
                     </div>

--- a/frontend/src/components/wardrobe/WardrobeCard.jsx
+++ b/frontend/src/components/wardrobe/WardrobeCard.jsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import { FiEdit2, FiTrash2, FiStar, FiUser, FiCheckCircle } from 'react-icons/fi'
 import { patchItem } from '../../api/wardrobe.js'
 import { resolveUrl } from '../../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 import ConfirmDialog from '../ui/ConfirmDialog.jsx'
 import RetryImage from '../ui/RetryImage.jsx'
 import TryOnModal from '../tryon/TryOnModal.jsx'
@@ -54,7 +55,7 @@ export default function WardrobeCard({ item, onDelete, selectMode = false, selec
         <div className="relative aspect-square bg-brand-100/60 dark:bg-brand-800/40 overflow-hidden">
           <RetryImage
             src={imageUrl}
-            alt={`${item.category} item`}
+            alt={wardrobeItemAlt(item)}
             loading="lazy"
             decoding="async"
             className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -15,6 +15,7 @@ import OOTDWidget from '../components/dashboard/OOTDWidget.jsx'
 import WardrobeStats from '../components/dashboard/WardrobeStats.jsx'
 import StyleDNACard from '../components/social/StyleDNACard.jsx'
 import { resolveUrl } from '../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../utils/wardrobeItemAlt.js'
 // import EidPlannerWidget from '../components/social/EidPlannerWidget.jsx'
 
 const stagger = { hidden: {}, show: { transition: { staggerChildren: 0.08 } } }
@@ -77,7 +78,7 @@ export default function DashboardPage() {
                 >
                   <RetryImage
                     src={resolveUrl(item.image_url)}
-                    alt={item.category}
+                    alt={wardrobeItemAlt(item)}
                     loading="lazy"
                     decoding="async"
                     className="w-full h-full object-cover"

--- a/frontend/src/pages/OutfitEditorPage.jsx
+++ b/frontend/src/pages/OutfitEditorPage.jsx
@@ -16,6 +16,7 @@ import CustomSelect from '../components/ui/CustomSelect.jsx'
 import { scoreToPercent } from '../utils/formatters.js'
 import OutfitTryOnModal from '../components/tryon/OutfitTryOnModal.jsx'
 import { resolveUrl } from '../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../utils/wardrobeItemAlt.js'
 
 const CAT_EMOJI = { top: '👕', bottom: '👖', outwear: '🧥', shoes: '👟', dress: '👗', jumpsuit: '🧘' }
 const CATEGORIES = ['all', 'top', 'bottom', 'outwear', 'shoes', 'dress', 'jumpsuit']
@@ -231,7 +232,7 @@ export default function OutfitEditorPage() {
                 >
                   <div className="aspect-square rounded-2xl overflow-hidden bg-brand-50/60 dark:bg-brand-800/40 border border-brand-100/60 dark:border-brand-700/40 group-hover:border-accent-400 transition-all duration-300 relative shadow-sm">
                     {item.image_url ? (
-                      <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />
+                      <img src={resolveUrl(item.image_url)} alt={wardrobeItemAlt(item)} className="w-full h-full object-cover" />
                     ) : (
                       <div className="w-full h-full flex items-center justify-center text-2xl opacity-40 grayscale">
                         {CAT_EMOJI[item.category] || '\u{1F454}'}
@@ -317,7 +318,7 @@ export default function OutfitEditorPage() {
                       >
                         <div className="aspect-square rounded-[24px] overflow-hidden bg-white dark:bg-brand-800 border-2 border-brand-100 dark:border-brand-700 shadow-elevated group-hover/item:shadow-card-hover transition-all duration-500 group-hover/item:-translate-y-2">
                           {item.image_url ? (
-                            <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />
+                            <img src={resolveUrl(item.image_url)} alt={wardrobeItemAlt(item)} className="w-full h-full object-cover" />
                           ) : (
                             <div className="w-full h-full flex items-center justify-center text-4xl opacity-60">
                               {CAT_EMOJI[item.category] || '👔'}
@@ -669,7 +670,7 @@ export default function OutfitEditorPage() {
                       >
                         <div className="aspect-square rounded-[28px] overflow-hidden bg-white dark:bg-brand-800 border-2 border-brand-100 dark:border-brand-700 shadow-elevated group-hover/fs:shadow-card-hover group-hover/fs:-translate-y-2 transition-all duration-400">
                           {item.image_url ? (
-                            <img src={resolveUrl(item.image_url)} alt={item.category} className="w-full h-full object-cover" />
+                            <img src={resolveUrl(item.image_url)} alt={wardrobeItemAlt(item)} className="w-full h-full object-cover" />
                           ) : (
                             <div className="w-full h-full flex items-center justify-center text-5xl opacity-60">
                               {CAT_EMOJI[item.category] || '👔'}
@@ -751,7 +752,7 @@ function SwapSuggestions({ suggestions, onSwap }) {
             >
               {imageUrl && (
                 <div className="w-12 h-12 rounded-xl overflow-hidden bg-brand-50 dark:bg-brand-800 border border-brand-100/60 dark:border-brand-700/40 flex-shrink-0 shadow-sm transition-transform group-hover/swap:scale-105">
-                  <img src={imageUrl} alt={s.add_item_category} className="w-full h-full object-cover" />
+                  <img src={imageUrl} alt={s.add_item_category || 'Wardrobe item'} className="w-full h-full object-cover" />
                 </div>
               )}
               <div className="flex-1 min-w-0">

--- a/frontend/src/pages/RecommendationsPage.jsx
+++ b/frontend/src/pages/RecommendationsPage.jsx
@@ -6,6 +6,7 @@ import { FiZap } from 'react-icons/fi'
 import { getRecommendations, getAroundItem } from '../api/recommendations.js'
 import { getItems } from '../api/wardrobe.js'
 import { resolveUrl } from '../utils/resolveUrl.js'
+import { wardrobeItemAlt } from '../utils/wardrobeItemAlt.js'
 import PageWrapper from '../components/layout/PageWrapper.jsx'
 import OccasionPicker from '../components/recommendations/OccasionPicker.jsx'
 import LocationToggle from '../components/recommendations/LocationToggle.jsx'
@@ -129,7 +130,7 @@ export default function RecommendationsPage() {
           <div className="w-14 h-14 rounded-xl overflow-hidden bg-white dark:bg-brand-800 border border-accent-200/60 dark:border-accent-700/40 flex items-center justify-center">
             <RetryImage
               src={resolveUrl(anchorItem.image_url)}
-              alt={anchorItem.category}
+              alt={wardrobeItemAlt(anchorItem)}
               loading="lazy"
               decoding="async"
               className="w-full h-full object-cover"

--- a/frontend/src/utils/wardrobeItemAlt.js
+++ b/frontend/src/utils/wardrobeItemAlt.js
@@ -1,0 +1,25 @@
+/**
+ * Build a descriptive alt text string for a wardrobe item image.
+ *
+ * Uses available metadata fields in priority order:
+ *   sub_category (e.g. "polo_shirt") → formality (when not "both") → category
+ *
+ * Gracefully degrades when fields are absent (recommendation API items only
+ * expose `category`; full wardrobe API items expose all three).
+ *
+ * Examples:
+ *   { sub_category: 'polo_shirt', formality: 'casual', category: 'top' }
+ *     → "polo shirt casual top"
+ *   { sub_category: null, formality: 'formal', category: 'bottom' }
+ *     → "formal bottom"
+ *   { category: 'shoes' }
+ *     → "shoes"
+ */
+export function wardrobeItemAlt(item) {
+  const parts = [
+    item.sub_category?.replace(/_/g, ' '),
+    item.formality && item.formality !== 'both' ? item.formality : null,
+    item.category,
+  ].filter(Boolean)
+  return parts.join(' ') || 'Wardrobe item'
+}


### PR DESCRIPTION
## Summary
- New utility `wardrobeItemAlt(item)` in `frontend/src/utils/wardrobeItemAlt.js` builds `"{sub_category} {formality} {category}"` from available fields, falling back gracefully when fields are absent (recommendation API items only expose `category`)
- Applied to all 14 `<img>` instances that render wardrobe items across 11 files
- Avatar images (`alt=""`) left unchanged — they are decorative and correctly empty

## Alt text examples
| Available fields | Result |
|---|---|
| sub_category=polo_shirt, formality=casual, category=top | "polo shirt casual top" |
| sub_category=null, formality=formal, category=bottom | "formal bottom" |
| category=shoes only (recommendation item) | "shoes" |
| formality=both, category=top | "top" (both omitted — not descriptive) |

## Test plan
- [x] Pre-push hook (full Python suite) — all green
- [ ] Frontend unit tests deferred to issue #99 (no test runner installed yet)
- [ ] Manual: screen reader announces wardrobe item descriptions on WardrobePage, RecommendationsPage, OutfitEditorPage

Closes #105