### PR TITLE
ux: rename 'Different' to 'Try Another', add category-aware empty states (#78 #81)

### DIFF
--- a/frontend/src/components/dashboard/OOTDWidget.jsx
+++ b/frontend/src/components/dashboard/OOTDWidget.jsx
@@ -221,10 +221,11 @@ export default function OOTDWidget() {
               refetch()
             }
           }}
+          title="Generate a different outfit recommendation"
           className="text-sm font-medium px-4 py-2.5 rounded-xl btn-secondary flex items-center justify-center gap-2"
         >
           <FiRefreshCw size={14} />
-          Different
+          Try Another
         </button>
       </div>
     </motion.div>

--- a/frontend/src/components/wardrobe/WardrobeGrid.jsx
+++ b/frontend/src/components/wardrobe/WardrobeGrid.jsx
@@ -1,14 +1,26 @@
 import WardrobeCard from './WardrobeCard.jsx'
 import EmptyState from '../ui/EmptyState.jsx'
 
-export default function WardrobeGrid({ items, onDelete, onUpload, selectMode, selectedIds, onToggleSelect }) {
+const CATEGORY_LABELS = {
+  top:      { noun: 'tops',       upload: 'Upload a Top' },
+  bottom:   { noun: 'bottoms',    upload: 'Upload a Bottom' },
+  outwear:  { noun: 'outerwear',  upload: 'Upload Outerwear' },
+  shoes:    { noun: 'shoes',      upload: 'Upload Shoes' },
+  dress:    { noun: 'dresses',    upload: 'Upload a Dress' },
+  jumpsuit: { noun: 'jumpsuits',  upload: 'Upload a Jumpsuit' },
+}
+
+export default function WardrobeGrid({ items, onDelete, onUpload, selectMode, selectedIds, onToggleSelect, filter }) {
   if (!items || items.length === 0) {
+    const cat = filter && filter !== 'all' ? CATEGORY_LABELS[filter] : null
     return (
       <EmptyState
         icon="👔"
-        title="Your wardrobe is empty"
-        description="Upload your first item to get started. Our AI will automatically detect the category."
-        action={{ label: '📸 Upload Item', onClick: onUpload }}
+        title={cat ? `No ${cat.noun} yet` : 'Your wardrobe is empty'}
+        description={cat
+          ? `You have no ${cat.noun} in your wardrobe. Upload one to get started.`
+          : 'Upload your first item to get started. Our AI will automatically detect the category.'}
+        action={{ label: cat ? `📸 ${cat.upload}` : '📸 Upload Item', onClick: onUpload }}
       />
     )
   }

--- a/frontend/src/pages/WardrobePage.jsx
+++ b/frontend/src/pages/WardrobePage.jsx
@@ -196,6 +196,7 @@ export default function WardrobePage() {
             selectMode={selectMode}
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}
+            filter={filter}
           />
         )}
 


### PR DESCRIPTION
## Summary
- Renamed the OOTD widget refresh button from 'Different' → 'Try Another' with a descriptive `title` tooltip for screen readers and keyboard users (#78)
- Added category-aware empty states to `WardrobeGrid`: when filtering by a specific category with no results, the empty state shows the category name and a targeted upload CTA (e.g. "No tops yet / Upload a Top") instead of the generic fallback (#81)
- Passes `filter` prop from `WardrobePage` down to `WardrobeGrid` to enable the category-aware messaging

## Test plan
- [ ] OOTD widget: button now reads "Try Another"; hover shows tooltip "Generate a different outfit recommendation"
- [ ] Wardrobe page, filter = 'top' with no tops: empty state shows "No tops yet" + "Upload a Top" CTA
- [ ] Wardrobe page, filter = 'all' with empty wardrobe: generic "Your wardrobe is empty" empty state unchanged
- [ ] 151 core tests pass, Vite build clean

Closes #78
Closes #81