### PR TITLE
a11y: add role=alert to ErrorMessage for assertive screen reader announcements (#107)

### DIFF
--- a/frontend/src/components/ui/ErrorMessage.jsx
+++ b/frontend/src/components/ui/ErrorMessage.jsx
@@ -2,7 +2,7 @@ import { FiAlertCircle } from 'react-icons/fi'
 
 export default function ErrorMessage({ message, onRetry }) {
   return (
-    <div className="rounded-xl bg-red-50/80 dark:bg-red-900/15 border border-red-200/60 dark:border-red-800/40 p-4 flex items-start gap-3">
+    <div role="alert" className="rounded-xl bg-red-50/80 dark:bg-red-900/15 border border-red-200/60 dark:border-red-800/40 p-4 flex items-start gap-3">
       <FiAlertCircle className="text-red-500 dark:text-red-400 flex-shrink-0 mt-0.5" size={16} />
       <div className="flex-1">
         <p className="text-red-700 dark:text-red-300 text-sm font-medium">{message || 'Something went wrong.'}</p>


### PR DESCRIPTION
## Summary
- Added `role="alert"` to the `ErrorMessage` component's root div, which is equivalent to `aria-live="assertive"` — screen readers will now interrupt and immediately announce error messages
- `LiveRegion`, `aria-busy`, and `aria-live="polite"` were already in place on `OOTDWidget`, `RecommendationsPage`, and `LoadingSpinner` from a prior pass; this closes the remaining gap in the acceptance criteria

## Test plan
- [ ] Trigger an error state (e.g. wardrobe load failure with network offline) — screen reader announces error immediately without waiting for silence
- [ ] Normal loading/result announcements unchanged (still polite)

Closes #107