### PR TITLE
feat: add human-readable color names to wardrobe palette swatches (#77)

### DIFF
--- a/app/wardrobe/routes.py
+++ b/app/wardrobe/routes.py
@@ -21,8 +21,10 @@ Routes (uploads_bp — JWT required via header or ?token= param):
 
 from __future__ import annotations
 
+import colorsys
 import json
 import logging
+import math
 import os
 import uuid
 
@@ -61,6 +63,49 @@ UPLOAD_TIPS = [
 def _pluralize_category(category: str) -> str:
     """Pluralize wardrobe category names with small irregular overrides."""
     return IRREGULAR_PLURALS.get(category, f"{category}s")
+
+
+# ─── Fashion color vocabulary ─────────────────────────────────────────────────
+# ~20 human-readable names mapped to representative RGB values.
+# Used to label wardrobe palette swatches in the Insights dashboard.
+
+_FASHION_COLORS: dict[str, tuple[int, int, int]] = {
+    "White":    (255, 255, 255),
+    "Ivory":    (255, 255, 240),
+    "Cream":    (255, 253, 208),
+    "Beige":    (245, 245, 220),
+    "Tan":      (210, 180, 140),
+    "Camel":    (193, 154, 107),
+    "Brown":    (139, 90, 43),
+    "Burgundy": (128, 0, 32),
+    "Red":      (220, 20, 60),
+    "Olive":    (107, 142, 35),
+    "Forest":   (34, 139, 34),
+    "Teal":     (0, 128, 128),
+    "Navy":     (0, 0, 128),
+    "Blue":     (70, 130, 180),
+    "Lavender": (230, 230, 250),
+    "Grey":     (128, 128, 128),
+    "Charcoal": (54, 69, 79),
+    "Black":    (0, 0, 0),
+}
+
+
+def _nearest_color_name(hue: float, sat: float, val: float) -> str:
+    """
+    Map an HSV colour (hue 0–360, sat/val 0–1) to the nearest fashion
+    colour name using Euclidean distance in RGB space.
+    """
+    r, g, b = colorsys.hsv_to_rgb(hue / 360.0, sat, val)
+    r8, g8, b8 = round(r * 255), round(g * 255), round(b * 255)
+    return min(
+        _FASHION_COLORS,
+        key=lambda name: math.sqrt(
+            (r8 - _FASHION_COLORS[name][0]) ** 2
+            + (g8 - _FASHION_COLORS[name][1]) ** 2
+            + (b8 - _FASHION_COLORS[name][2]) ** 2
+        ),
+    )
 
 
 # ─── POST /wardrobe/items ─────────────────────────────────────────────────────
@@ -474,7 +519,12 @@ def wardrobe_stats():
 
     # ── Color data ───────────────────────────────────────────────────────────
     colors = [
-        {"hue": i.color_hue, "sat": i.color_sat, "val": i.color_val}
+        {
+            "hue": i.color_hue,
+            "sat": i.color_sat,
+            "val": i.color_val,
+            "name": _nearest_color_name(i.color_hue, i.color_sat, i.color_val),
+        }
         for i in items
     ]
 

--- a/frontend/src/components/dashboard/WardrobeStats.jsx
+++ b/frontend/src/components/dashboard/WardrobeStats.jsx
@@ -31,17 +31,22 @@ function CategoryBar({ category, count, max, delay }) {
   )
 }
 
-function ColorDot({ hue, sat, val }) {
+function ColorDot({ hue, sat, val, name }) {
   const l = val * (1 - sat / 2)
   const s = l === 0 || l === 1 ? 0 : ((val - l) / Math.min(l, 1 - l)) * 100
   const color = `hsl(${hue}, ${Math.round(s)}%, ${Math.round(l * 100)}%)`
   return (
-    <motion.div
-      whileHover={{ scale: 1.3 }}
-      className="w-6 h-6 rounded-full border border-brand-200/60 dark:border-brand-700/40 shadow-sm cursor-default"
-      style={{ backgroundColor: color }}
-      title={`H:${Math.round(hue)} S:${(sat * 100).toFixed(0)}% V:${(val * 100).toFixed(0)}%`}
-    />
+    <div className="flex flex-col items-center gap-1">
+      <motion.div
+        whileHover={{ scale: 1.3 }}
+        className="w-6 h-6 rounded-full border border-brand-200/60 dark:border-brand-700/40 shadow-sm cursor-default"
+        style={{ backgroundColor: color }}
+        title={name ?? `H:${Math.round(hue)} S:${(sat * 100).toFixed(0)}% V:${(val * 100).toFixed(0)}%`}
+      />
+      {name && (
+        <span className="text-[9px] text-brand-500 dark:text-brand-400 font-medium leading-none">{name}</span>
+      )}
+    </div>
   )
 }
 
@@ -114,7 +119,7 @@ export default function WardrobeStats() {
           <p className="label-xs mb-2">Color Palette</p>
           <div className="flex flex-wrap gap-1.5">
             {colors.map((c, i) => (
-              <ColorDot key={i} hue={c.hue} sat={c.sat} val={c.val} />
+              <ColorDot key={i} hue={c.hue} sat={c.sat} val={c.val} name={c.name} />
             ))}
           </div>
         </div>

--- a/tests/test_flask_stats_ootd.py
+++ b/tests/test_flask_stats_ootd.py
@@ -390,3 +390,50 @@ class TestOOTD:
         assert "color_score" in body["outfit"]
         assert "weather_score" in body["outfit"]
         assert "synergy_score" in body["outfit"]  # Added synergy score validation
+
+
+# ─── Color naming unit tests ──────────────────────────────────────────────────
+
+class TestNearestColorName:
+    """Unit tests for _nearest_color_name — no Flask context required."""
+
+    def setup_method(self):
+        from app.wardrobe.routes import _nearest_color_name
+        self._fn = _nearest_color_name
+
+    def _hsv(self, r, g, b):
+        """Convert RGB (0-255) to HSV (hue 0-360, sat/val 0-1)."""
+        import colorsys
+        h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+        return h * 360, s, v
+
+    def test_beige(self):
+        assert self._fn(*self._hsv(245, 245, 220)) == "Beige"
+
+    def test_navy(self):
+        assert self._fn(*self._hsv(0, 0, 128)) == "Navy"
+
+    def test_black(self):
+        assert self._fn(*self._hsv(0, 0, 0)) == "Black"
+
+    def test_white(self):
+        assert self._fn(*self._hsv(255, 255, 255)) == "White"
+
+    def test_red(self):
+        assert self._fn(*self._hsv(220, 20, 60)) == "Red"
+
+
+class TestStatsColorNames:
+    """Integration: /wardrobe/stats returns color objects with a `name` field."""
+
+    def test_stats_colors_have_name(self, flask_app, client, auth_headers, minimal_png):
+        with flask_app.app_context():
+            _upload_item(client, auth_headers, minimal_png, category="top")
+
+        resp = client.get("/wardrobe/stats", headers=auth_headers)
+        assert resp.status_code == 200
+        colors = resp.get_json()["wardrobe"]["colors"]
+        assert len(colors) == 1
+        assert "name" in colors[0]
+        assert isinstance(colors[0]["name"], str)
+        assert len(colors[0]["name"]) > 0


### PR DESCRIPTION
## Summary
- Added `_FASHION_COLORS` dict (18 fashion-specific RGB anchors) and `_nearest_color_name(hue, sat, val)` to `app/wardrobe/routes.py` — converts HSV → RGB then finds the nearest color by Euclidean distance
- `/wardrobe/stats` now includes a `name` field on every color object (e.g. `{"hue": 240, "sat": 1.0, "val": 0.5, "name": "Navy"}`)
- `WardrobeStats.jsx` `ColorDot` updated to render the name as a small label below each swatch; tooltip now shows the name instead of raw HSV values

## Test plan
- [ ] Dashboard Insights → Color Palette: each swatch shows a legible name label (e.g. "Navy", "Cream", "Charcoal")
- [ ] Tooltip on hover shows color name
- [ ] Dark mode and light mode both render correctly
- [ ] 6 new tests pass: 5 unit tests (`Beige`, `Navy`, `Black`, `White`, `Red` mappings) + 1 integration test (`name` field present in stats response)

Closes #77