### PR TITLE
a11y: add aria-label with unread count to notification bell (#94)

### DIFF
--- a/frontend/src/components/layout/Navbar.jsx
+++ b/frontend/src/components/layout/Navbar.jsx
@@ -103,6 +103,7 @@ export default function Navbar() {
               <button
                 onClick={() => setNotifOpen(o => !o)}
                 className="relative flex items-center justify-center w-9 h-9 rounded-xl text-brand-500 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-200 transition-colors hover:bg-brand-100/60 dark:hover:bg-brand-800/30"
+                aria-label={unreadCount > 0 ? `Notifications, ${unreadCount > 9 ? '9+' : unreadCount} unread` : 'Notifications'}
                 title="Notifications"
               >
                 <FiBell size={17} />


### PR DESCRIPTION
## Summary
The notification bell badge (red count indicator) was already fully implemented — backend `/social/notifications/count` endpoint, `getNotificationCount` query, and the badge UI with `unreadCount > 9 ? '9+' : unreadCount` display. The only missing piece was the accessible label.

Added dynamic `aria-label` to the bell button: `"Notifications, 3 unread"` when there are unread notifications, `"Notifications"` when all are read. Screen readers now announce the unread state without requiring the user to open the panel.

## Test plan
- [ ] Screen reader: bell announces "Notifications, 3 unread" when badge is shown
- [ ] Screen reader: bell announces "Notifications" when badge is hidden
- [ ] Visual badge behaviour unchanged

Closes #94