### PR TITLE
ui: standardize stat-box style across dashboard (#83)

### DIFF
--- a/frontend/src/components/dashboard/WardrobeStats.jsx
+++ b/frontend/src/components/dashboard/WardrobeStats.jsx
@@ -122,22 +122,22 @@ export default function WardrobeStats() {
 
       {/* Activity */}
       <div className="grid grid-cols-2 gap-3 mb-5">
-        <div className="bg-brand-50/60 dark:bg-brand-800/30 rounded-xl p-3 text-center border border-brand-100/40 dark:border-brand-800/30">
+        <div className="stat-box">
           <div className="text-xl font-mono font-bold text-brand-900 dark:text-brand-100">{activity.total_recommendations ?? 0}</div>
           <div className="text-[10px] text-brand-500 dark:text-brand-400 mt-0.5">Recommendations</div>
         </div>
-        <div className="bg-brand-50/60 dark:bg-brand-800/30 rounded-xl p-3 text-center border border-brand-100/40 dark:border-brand-800/30">
+        <div className="stat-box">
           <div className="text-xl font-mono font-bold text-brand-900 dark:text-brand-100">{activity.saved_outfits ?? 0}</div>
           <div className="text-[10px] text-brand-500 dark:text-brand-400 mt-0.5">Saved</div>
         </div>
         {activity.avg_score != null && (
-          <div className="bg-brand-50/60 dark:bg-brand-800/30 rounded-xl p-3 text-center border border-brand-100/40 dark:border-brand-800/30">
+          <div className="stat-box">
             <div className="text-xl font-mono font-bold text-brand-900 dark:text-brand-100">{Math.round(activity.avg_score * 100)}%</div>
             <div className="text-[10px] font-medium text-accent-700 dark:text-accent-400 mt-0.5">{scoreToLabel(activity.avg_score)}</div>
           </div>
         )}
         {(feedback.thumbs_up > 0 || feedback.thumbs_down > 0) && (
-          <div className="bg-brand-50/60 dark:bg-brand-800/30 rounded-xl p-3 text-center border border-brand-100/40 dark:border-brand-800/30">
+          <div className="stat-box">
             <div className="text-lg font-mono font-bold">
               <span className="text-emerald-600 dark:text-emerald-400">{feedback.thumbs_up ?? 0}</span>
               <span className="text-brand-300 dark:text-brand-600 mx-0.5">/</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -82,6 +82,12 @@
            dark:hover:border-brand-700 dark:hover:shadow-lg dark:hover:shadow-brand-950/20;
   }
 
+  /* ─── Stat box (metric / counter cell inside a card) ─── */
+  .stat-box {
+    @apply bg-brand-50/70 dark:bg-brand-800/35 rounded-xl border border-brand-100/50
+           dark:border-brand-800/35 p-3 text-center;
+  }
+
   /* ─── Glass Card (premium variant) ─── */
   .card-glass {
     @apply bg-white/60 backdrop-blur-md rounded-2xl border border-white/40

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -133,7 +133,7 @@ export default function DashboardPage() {
                       initial={{ opacity: 0, scale: 0.9 }}
                       animate={{ opacity: 1, scale: 1 }}
                       transition={{ delay: i * 0.05, duration: 0.3 }}
-                      className="text-center p-3 bg-brand-50/80 dark:bg-brand-800/40 rounded-xl border border-brand-100/60 dark:border-brand-800/40"
+                      className="stat-box"
                     >
                       <div className="text-3xl font-mono font-bold text-brand-900 dark:text-brand-100">{count}</div>
                       <div className="label-xs mt-1">{pluralizeCategory(cat)}</div>


### PR DESCRIPTION
## Summary
The `.card` / `.card-glass` / `.card-hover` system was already consistent across the app. The only actual inconsistency was the inline metric cell styles in `WardrobeStats` and `DashboardPage`, which had slightly different opacity/border opacity values.

- Added `.stat-box` utility class to `index.css` — single source of truth for metric/counter cells inside cards
- Applied `.stat-box` in `DashboardPage.jsx` (category count cells in Wardrobe Health)
- Applied `.stat-box` in `WardrobeStats.jsx` (Recommendations / Saved / Avg Score / Feedback cells)
- Semantic alert banners (amber, emerald, sky) kept their contextual colors — not unified with stat-box

## Card system (documented)
| Class | Use | Style |
|---|---|---|
| `.card` | Standard content card | white/80 bg, brand-100 border, shadow-card |
| `.card-glass` | Premium/elevated panel (modals, featured) | white/60 bg, white/40 border, backdrop-blur-md |
| `.card-hover` | Interactive card with hover lift | extends `.card` + translate + shadow |
| `.stat-box` | Metric cell inside a card | brand-50/70 bg, brand-100/50 border |

## Test plan
- [ ] Dashboard light mode: Wardrobe Health category cells look uniform
- [ ] Dashboard dark mode: same cells visible with correct dark bg
- [ ] Insights panel: Recommendations/Saved/Avg Score/Feedback cells consistent
- [ ] No visual regressions on other card types (OutfitCard, WardrobeItem, SavedOutfits)

Closes #83