### PR TITLE
feat: add demo step to onboarding flow (#114)

### DIFF
--- a/frontend/src/components/onboarding/OnboardingFlow.jsx
+++ b/frontend/src/components/onboarding/OnboardingFlow.jsx
@@ -2,10 +2,52 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../../context/AuthContext.jsx'
 import { motion, AnimatePresence } from 'framer-motion'
-import { FiArrowRight, FiUploadCloud, FiZap } from 'react-icons/fi'
+import { FiArrowRight, FiUploadCloud, FiZap, FiStar } from 'react-icons/fi'
 import UploadModal from '../wardrobe/UploadModal.jsx'
 import { useQuery } from '@tanstack/react-query'
 import { getItems } from '../../api/wardrobe.js'
+
+const TOTAL_STEPS = 4
+
+// Static demo outfit — no backend, no images required
+const DEMO_OUTFIT = {
+  items: [
+    { category: 'top',    emoji: '👔', label: 'Oxford Shirt',   color: 'bg-sky-100 dark:bg-sky-900/30' },
+    { category: 'bottom', emoji: '👖', label: 'Chino Trousers', color: 'bg-stone-100 dark:bg-stone-800/40' },
+    { category: 'shoes',  emoji: '👞', label: 'Leather Loafers', color: 'bg-amber-100 dark:bg-amber-900/30' },
+  ],
+  finalScore: 0.87,
+  model2_score:   0.91,
+  synergy_score:  0.80,
+  color_score:    0.85,
+  cohesion_score: 0.88,
+  weather_score:  0.82,
+  occasion: 'Smart Casual',
+}
+
+function pct(v) { return Math.round((v ?? 0) * 100) }
+
+function DemoScoreBar({ label, value, weight }) {
+  const p = pct(value)
+  const color = p >= 70 ? 'bg-emerald-500' : p >= 50 ? 'bg-accent-500' : 'bg-red-500'
+  return (
+    <div>
+      <div className="flex justify-between text-[11px] text-brand-500 dark:text-brand-400 mb-1">
+        <span>{label}</span>
+        <span className="font-mono font-semibold">{p}%</span>
+      </div>
+      <div className="h-1.5 bg-brand-200/60 dark:bg-brand-700/40 rounded-full overflow-hidden">
+        <motion.div
+          className={`h-full ${color} rounded-full`}
+          initial={{ width: 0 }}
+          animate={{ width: `${p}%` }}
+          transition={{ duration: 0.7, ease: 'easeOut', delay: 0.3 }}
+        />
+      </div>
+      {weight && <div className="text-[9px] text-brand-300 dark:text-brand-600 mt-0.5 text-right">{weight} weight</div>}
+    </div>
+  )
+}
 
 export default function OnboardingFlow() {
   const [step, setStep] = useState(1)
@@ -13,7 +55,6 @@ export default function OnboardingFlow() {
   const { user } = useAuth()
   const navigate = useNavigate()
 
-  // Issue 20: redirect already-onboarded users back to dashboard
   useEffect(() => {
     if (localStorage.getItem('onboarding_done') === '1') {
       navigate('/dashboard', { replace: true })
@@ -38,7 +79,7 @@ export default function OnboardingFlow() {
         <div className="w-full max-w-md">
           {/* Progress */}
           <div className="flex justify-center gap-2 mb-8">
-            {[1, 2, 3].map(s => (
+            {Array.from({ length: TOTAL_STEPS }, (_, i) => i + 1).map(s => (
               <motion.div
                 key={s}
                 animate={{ width: s === step ? 32 : 8 }}
@@ -77,10 +118,79 @@ export default function OnboardingFlow() {
               </motion.div>
             )}
 
-            {/* Step 2: Upload */}
+            {/* Step 2: Demo */}
             {step === 2 && (
               <motion.div
                 key="step2"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+                className="card p-6 shadow-elevated"
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <FiStar size={14} className="text-accent-500" />
+                  <span className="label-xs text-accent-600 dark:text-accent-400">Preview</span>
+                </div>
+                <h2 className="font-display text-2xl font-bold text-brand-900 dark:text-brand-100 mb-1">
+                  See what OutfitAI does
+                </h2>
+                <p className="text-sm text-brand-500 dark:text-brand-400 mb-5 leading-relaxed">
+                  Complete outfits scored by style compatibility, color harmony, and weather suitability — built from your wardrobe.
+                </p>
+
+                {/* Demo outfit card */}
+                <div className="bg-brand-50/60 dark:bg-brand-800/30 rounded-2xl p-4 mb-5">
+                  {/* Header */}
+                  <div className="flex items-center justify-between mb-3">
+                    <span className="text-xs font-medium text-brand-500 dark:text-brand-400">{DEMO_OUTFIT.occasion}</span>
+                    <div className="flex items-center gap-1.5 bg-brand-900 dark:bg-brand-100 text-white dark:text-brand-900 rounded-full px-2.5 py-1">
+                      <FiStar size={10} />
+                      <span className="text-xs font-bold">{pct(DEMO_OUTFIT.finalScore)}% Match</span>
+                    </div>
+                  </div>
+
+                  {/* Item thumbnails */}
+                  <div className="flex gap-2 mb-4">
+                    {DEMO_OUTFIT.items.map((item, i) => (
+                      <div key={i} className="flex-1 flex flex-col items-center gap-1.5">
+                        <div className={`w-full aspect-square rounded-xl ${item.color} flex items-center justify-center text-3xl border border-brand-100/60 dark:border-brand-700/40`}>
+                          {item.emoji}
+                        </div>
+                        <span className="text-[10px] text-brand-500 dark:text-brand-400 text-center leading-tight">{item.label}</span>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Score breakdown */}
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-2.5 pt-3 border-t border-brand-100/60 dark:border-brand-700/40">
+                    <DemoScoreBar label="Style"    value={DEMO_OUTFIT.model2_score}   weight="35%" />
+                    <DemoScoreBar label="Synergy"  value={DEMO_OUTFIT.synergy_score}  weight="20%" />
+                    <DemoScoreBar label="Color"    value={DEMO_OUTFIT.color_score}    weight="20%" />
+                    <DemoScoreBar label="Weather"  value={DEMO_OUTFIT.weather_score}  weight="15%" />
+                    <DemoScoreBar label="Cohesion" value={DEMO_OUTFIT.cohesion_score} weight="10%" />
+                  </div>
+                </div>
+
+                <button
+                  onClick={() => setStep(3)}
+                  className="btn-primary w-full py-3 text-base flex items-center justify-center gap-2 group mb-3"
+                >
+                  Build my wardrobe <FiArrowRight size={16} className="transition-transform group-hover:translate-x-0.5" />
+                </button>
+                <button
+                  onClick={() => setStep(3)}
+                  className="w-full text-center text-sm text-brand-500 hover:text-brand-600 dark:hover:text-brand-300 py-2 transition-colors"
+                >
+                  Skip preview
+                </button>
+              </motion.div>
+            )}
+
+            {/* Step 3: Upload */}
+            {step === 3 && (
+              <motion.div
+                key="step3"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -20 }}
@@ -111,21 +221,21 @@ export default function OnboardingFlow() {
                 </button>
 
                 {itemCount >= 3 && (
-                  <button onClick={() => setStep(3)} className="btn-secondary w-full flex items-center justify-center gap-2 group">
+                  <button onClick={() => setStep(4)} className="btn-secondary w-full flex items-center justify-center gap-2 group">
                     Continue <FiArrowRight size={14} className="transition-transform group-hover:translate-x-0.5" />
                   </button>
                 )}
 
-                <button onClick={() => setStep(3)} className="w-full text-center text-sm text-brand-500 hover:text-brand-600 dark:hover:text-brand-300 mt-4 py-2 transition-colors">
+                <button onClick={() => setStep(4)} className="w-full text-center text-sm text-brand-500 hover:text-brand-600 dark:hover:text-brand-300 mt-4 py-2 transition-colors">
                   Skip for now
                 </button>
               </motion.div>
             )}
 
-            {/* Step 3: Done */}
-            {step === 3 && (
+            {/* Step 4: Done */}
+            {step === 4 && (
               <motion.div
-                key="step3"
+                key="step4"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -20 }}


### PR DESCRIPTION
Closes #114

## Summary
- Inserts a new "See what OutfitAI does" step between Welcome and Upload (flow is now 4 steps)
- Static demo outfit card: Oxford shirt + chinos + loafers, 87% match — no backend, no stock images
- Animated score bars (Style 91%, Synergy 80%, Color 85%, Weather 82%, Cohesion 88%) rendered inline — reuses same visual pattern as `WhyThisOutfit`
- "Build my wardrobe →" CTA advances to upload; "Skip preview" also available
- Progress dots updated from 3 → 4

## Test plan
- [ ] New user onboarding: demo step visible between Welcome and Upload
- [ ] Score bars animate in on load
- [ ] "Build my wardrobe" → advances to Upload step
- [ ] "Skip preview" → also advances to Upload step
- [ ] Demo renders correctly in light and dark mode
- [ ] Existing onboarding steps (Upload, Done) unchanged

## Preflight
- 153 backend tests passed
- Vite build clean