### PR TITLE
fix: remove false formality-mixing violation from outfit editor

### DIFF
--- a/app/recommendations/routes.py
+++ b/app/recommendations/routes.py
@@ -596,9 +596,10 @@ def _check_rule_violations(items: list) -> list[str]:
         dupes = [cat.value for cat, count in Counter(categories).items() if count > 1]
         violations.append(f"Duplicate categories: {', '.join(dupes)}.")
 
-    strict = {item.formality for item in items if item.formality != Formality.BOTH}
-    if Formality.CASUAL in strict and Formality.FORMAL in strict:
-        violations.append("Cannot mix casual and formal items in one outfit.")
+    # Note: cross-formality mixing (casual + formal) is intentionally ALLOWED.
+    # Smart casual (casual shirt + formal trousers, blazer + jeans) is the most
+    # common modern dress code. Genuinely bad combos are caught by Tier B
+    # sub-category blocked pairs in engine/hard_rules.py (e.g. hoodie + dress_trousers).
 
     return violations
 


### PR DESCRIPTION
## Summary
- Remove the blanket casual+formal mixing block from the score-outfit endpoint
- A casual shirt + formal trousers was showing "Critical Mismatch" in the editor — this is wrong, smart casual is valid
- The engine (`hard_rules.py`) already intentionally allows cross-formality mixing; specific bad combos are caught by Tier B sub-category blocked pairs (hoodie+dress_trousers, etc.)

## Test plan
- [x] 153 backend tests pass
- [x] `test_flask_score_outfit.py` + `test_hard_rules.py` — 36 tests pass
- [ ] Manual: open editor, pair casual top + formal bottom → no "Critical Mismatch"