### PR TITLE
fix: feedback history_id + VTO category filter + stale weights

### DIFF
--- a/app/outfits/routes.py
+++ b/app/outfits/routes.py
@@ -327,7 +327,7 @@ def _run_weight_optimization(app, positives: int, negatives: int) -> None:
                 "  Pearson correlation: %.4f\n"
                 "  Positive: %d | Negative: %d\n"
                 "  Interpretation: %.1f%% of the time, scored-higher outfit also got thumbs-up.\n"
-                "  Current weights: model2=0.45, color=0.25, weather=0.15, cohesion=0.15\n"
+                "  Current weights: model2=0.35, synergy=0.20, color=0.20, weather=0.15, cohesion=0.10\n"
                 "  %s",
                 len(rows), auc, corr, positives, negatives, auc * 100,
                 "Weights performing well (AUC > 0.65)." if auc > 0.65

--- a/app/recommendations/routes.py
+++ b/app/recommendations/routes.py
@@ -135,6 +135,7 @@ def _format_outfits_response(
     filename_map: dict[int, str],
     temp_celsius: float,
     occasion: str,
+    history_ids: list[int] | None = None,
 ) -> dict:
     """Build the JSON-serialisable response dict for recommendation results."""
     has_low_confidence = any(o.confidence == "low" for o in outfits)
@@ -150,7 +151,7 @@ def _format_outfits_response(
                 "category":  eng_item.category.value,
                 "image_url": _img_url(img_filename),
             })
-        formatted_outfits.append({
+        entry = {
             "rank":           rank,
             "final_score":    round(outfit.final_score, 4),
             "confidence":     outfit.confidence,
@@ -161,7 +162,10 @@ def _format_outfits_response(
             "synergy_score":  round(outfit.synergy_score, 4),
             "items":          outfit_items,
             "template":       outfit.template_id.value if outfit.template_id else None,
-        })
+        }
+        if history_ids and rank <= len(history_ids):
+            entry["history_id"] = history_ids[rank - 1]
+        formatted_outfits.append(entry)
 
     return {
         "outfits":            formatted_outfits,
@@ -172,13 +176,16 @@ def _format_outfits_response(
     }
 
 
-def _log_history(user_id: int, occasion: str, temp_celsius: float, outfits: list) -> None:
+def _log_history(user_id: int, occasion: str, temp_celsius: float, outfits: list) -> list[int]:
     """
     Persist each outfit in `outfits` to outfit_history.
     Called after a successful recommendation — failures are logged but do NOT
     abort the recommendation response.
+
+    Returns list of history entry IDs (used by FeedbackButtons in the frontend).
     """
     try:
+        entries = []
         for outfit in outfits:
             entry = OutfitHistory(
                 user_id          = user_id,
@@ -190,11 +197,14 @@ def _log_history(user_id: int, occasion: str, temp_celsius: float, outfits: list
                 template         = getattr(outfit.template_id, 'value', str(outfit.template_id)) if outfit.template_id else '',
             )
             db.session.add(entry)
+            entries.append(entry)
         db.session.commit()
         logger.info("Logged %d outfit(s) to history for user %s", len(outfits), user_id)
+        return [e.id for e in entries]
     except Exception as exc:
         db.session.rollback()
         logger.error("Failed to log outfit history: %s", exc, exc_info=True)
+        return []
 
 
 # ─── POST /recommendations ────────────────────────────────────────────────────
@@ -255,11 +265,11 @@ def recommend():
         return jsonify({"error": "Recommendation engine failed. Please try again."}), 500
 
     # 6. Auto-log each outfit to history
-    _log_history(user_id, occasion, temp_celsius, outfits)
+    history_ids = _log_history(user_id, occasion, temp_celsius, outfits)
 
     # 7. Format, cache, and return response
     filename_map = {item.id: item.image_filename for item in items_db}
-    response_data = _format_outfits_response(outfits, filename_map, temp_celsius, occasion)
+    response_data = _format_outfits_response(outfits, filename_map, temp_celsius, occasion, history_ids)
     recommendation_cache.put(user_id, occasion, temp_celsius, response_data)
     return _with_private_cache(jsonify(response_data)), 200
 

--- a/frontend/src/components/tryon/OutfitTryOnModal.jsx
+++ b/frontend/src/components/tryon/OutfitTryOnModal.jsx
@@ -6,8 +6,11 @@ import TryOnModal from './TryOnModal.jsx'
 import { resolveUrl } from '../../utils/resolveUrl.js'
 import { wardrobeItemAlt } from '../../utils/wardrobeItemAlt.js'
 
+// Categories that FASHN VTON supports (shoes cannot be virtually tried on)
+const VTO_SUPPORTED = new Set(['top', 'outwear', 'bottom', 'dress', 'jumpsuit'])
+
 // Hero priority — most visually impactful garments first
-const HERO_PRIORITY = ['dress', 'jumpsuit', 'top', 'outwear', 'bottom', 'shoes']
+const HERO_PRIORITY = ['dress', 'jumpsuit', 'top', 'outwear', 'bottom']
 
 function pickHero(items) {
   if (!items?.length) return null
@@ -22,9 +25,9 @@ export default function OutfitTryOnModal({ open, onClose, items, occasion }) {
   const [selectedItem, setSelectedItem] = useState(null)
   const [tryOnOpen, setTryOnOpen] = useState(false)
 
-  // Filter to items that have an id (needed for backend VTO job)
+  // Filter to items that VTO can actually process (shoes are not supported)
   const tryableItems = useMemo(
-    () => (items ?? []).filter(i => i.id && i.image_url),
+    () => (items ?? []).filter(i => i.id && i.image_url && VTO_SUPPORTED.has(i.category)),
     [items]
   )
 


### PR DESCRIPTION
## Summary
- **Feedback buttons fix**: `_log_history` now returns entry IDs; `_format_outfits_response` includes `history_id` per outfit so `FeedbackButtons` renders thumbs up/down (was always `null` → component returned early)
- **VTO category filter**: `OutfitTryOnModal` filters items to `VTO_SUPPORTED` set (top, outwear, bottom, dress, jumpsuit) — excludes shoes which FASHN VTON cannot process
- **Stale optimizer log**: Updated weight string in `_maybe_optimize_weights_async` from old 4-component values to live 5-component weights (model2=0.35, synergy=0.20, color=0.20, weather=0.15, cohesion=0.10)

## Test plan
- [x] 317 backend tests pass
- [x] Frontend vite build clean (0 warnings)
- [x] ESLint clean on changed files
- [x] Preflight hook passed (migrations, pytest, vite)