### PR TITLE
fix: remove unused Formality import breaking CI flake8

### DIFF
--- a/app/recommendations/routes.py
+++ b/app/recommendations/routes.py
@@ -587,7 +587,7 @@ def score_outfit_endpoint():
 
 def _check_rule_violations(items: list) -> list[str]:
     """Return human-readable descriptions of hard rule violations."""
-    from engine.models import Category, Formality
+    from engine.models import Category
 
     violations = []
     categories = [item.category for item in items]


### PR DESCRIPTION
## Summary
- Remove unused `Formality` import in `_check_rule_violations` (left over from PR #182 which removed the blanket casual+formal block)
- CI flake8 catches this as F401

## Test plan
- [x] `flake8 app/ engine/` with CI config — 0 errors
- [x] 153 core tests pass
- [x] Frontend build clean
- [x] Preflight 4/4 passed