### PR TITLE
fix: hide Virtual Try-On button on shoe wardrobe cards

### DIFF
--- a/frontend/src/components/wardrobe/WardrobeCard.jsx
+++ b/frontend/src/components/wardrobe/WardrobeCard.jsx
@@ -212,12 +212,14 @@ export default function WardrobeCard({ item, onDelete, _onArchive, selectMode = 
               >
                 <FiStar size={13} /> Build outfit
               </button>
-              <button
-                onClick={() => setTryOnOpen(true)}
-                className="w-full text-xs text-brand-500 dark:text-brand-400 font-medium py-2 border border-brand-200/60 dark:border-brand-700/40 rounded-lg hover:bg-brand-50/60 dark:hover:bg-brand-800/40 transition-all flex items-center justify-center gap-1.5"
-              >
-                <FiUser size={12} /> Virtual Try-On
-              </button>
+              {item.category !== 'shoes' && (
+                <button
+                  onClick={() => setTryOnOpen(true)}
+                  className="w-full text-xs text-brand-500 dark:text-brand-400 font-medium py-2 border border-brand-200/60 dark:border-brand-700/40 rounded-lg hover:bg-brand-50/60 dark:hover:bg-brand-800/40 transition-all flex items-center justify-center gap-1.5"
+                >
+                  <FiUser size={12} /> Virtual Try-On
+                </button>
+              )}
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Hide "Virtual Try-On" button on wardrobe cards when item category is `shoes`
- FASHN VTON cannot process footwear — previously shoes were mapped to `"tops"` producing garbage results
- Complements PR #183 which filtered shoes in the OutfitTryOnModal (the modal after clicking); this fixes the button visibility on individual wardrobe cards

## Test plan
- [x] ESLint clean (0 warnings)
- [x] Vite build clean
- [x] 153 core tests pass
- [x] Preflight 4/4 passed